### PR TITLE
Full v2 parity + security/dep fixes + TS types (1.1.0)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,32 @@
+name: Publish to npm
+
+# Publishes idanalyzer2 to npm when a version tag (v*) is pushed.
+# Uses npm Trusted Publishing (OIDC) — no NPM_TOKEN secret required.
+# Configure the trusted publisher on npmjs.com: Publisher=GitHub Actions,
+# Org=idanalyzer, Repo=id-analyzer-v2-nodejs, Workflow=publish.yml, Environment=(blank).
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write   # required for OIDC trusted publishing + provenance
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          registry-url: 'https://registry.npmjs.org'
+
+      # Trusted publishing requires npm >= 11.5.1
+      - run: npm install -g npm@latest
+
+      - run: npm publish --provenance --access public

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,35 @@
+# Changelog
+
+## 1.1.0 (2026-06-03)
+
+Full API v2 surface parity, security fixes, modern deps, and TypeScript types.
+
+### Security / Fixed
+- **Removed `httpsAgent: { rejectUnauthorized: false }`** — the SDK was disabling
+  TLS certificate verification on every request (silent MITM exposure). TLS is now
+  verified normally.
+- **Bumped `axios` `^0.21.4` → `^1.7.7`** (the 0.21 line carries known CVEs incl.
+  CVE-2023-45857) and **removed the deprecated `moment` dependency** (date check is
+  now a small regex + `Date`).
+- **Base URL** default `v2-us1.idanalyzer.com` (single node, no Cloudflare/LB/HA) →
+  load-balanced **`api2.idanalyzer.com`**. EU unchanged (`api2-eu` via `IDANALYZER_REGION=eu`).
+- Unknown `IDANALYZER_REGION` now throws `InvalidArgumentException` instead of
+  returning `undefined` (which broke every request).
+- Fixed `Profile.webhook()` protocol guard (`!== 'http' || !== 'https'` was always
+  true and compared without the `:` suffix → rejected every URL).
+- Fixed `Transaction.listTransaction` and `Docupass.listDocupass` passing query
+  params as the axios request body — filters/pagination were never sent.
+- Fixed the age-range regex (`^\d+-\d$` → `^\d+-\d+$`) so multi-digit max ages validate.
+- Removed leftover `console.log(1)`/`console.log(2)` debug output from `updateTemplate`.
+- Constructor now honours the `IDANALYZER_KEY` environment variable.
+
+### Added
+- `Scanner.veryQuickScan` → `POST /veryquickscan`.
+- `AML` class — `search` (`POST /aml`, incl. optional `birthYear`) and `searchV3`
+  (`POST /amlv3`).
+- `Docupass.getDocupass` → `GET /docupass/{reference}`.
+- `ProfileAPI` class — server-side KYC profile CRUD + export.
+- `Webhook` class — `listWebhook`/`resendWebhook`/`deleteWebhook`.
+- `Account` class — `getAccount` (`GET /myaccount`).
+- **Bundled TypeScript definitions** (`index.d.ts`).
+- `engines.node >= 18`.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,32 @@ Install through npm
 npm install idanalyzer2
 ```
 
+TypeScript type definitions are bundled (`index.d.ts`) — no `@types` package needed.
+
+## Base URL / Region
+By default the SDK targets the US fleet (`https://api2.idanalyzer.com`). To use the
+EU fleet (`https://api2-eu.idanalyzer.com`), set the `IDANALYZER_REGION` environment
+variable to `eu` before instantiating any client:
+
+```bash
+export IDANALYZER_REGION=eu   # "us" (default) or "eu"
+```
+
+An unrecognized region value throws `InvalidArgumentException`. For on-premise ID Fort
+deployments, call `SetEndpoint('https://your-host/')`.
+
+## API Coverage
+The SDK exposes the full ID Analyzer API v2 surface:
+
+- **Scanner** — `scan`, `quickScan`, `veryQuickScan`
+- **Biometric** — `verifyFace`, `verifyLiveness`
+- **AML** — `search` (`/aml`), `searchV3` (`/amlv3`)
+- **Contract** — `generate` + template CRUD
+- **Transaction** — get/list/update/delete, export, `saveImage`/`saveFile`
+- **Docupass** — `createDocupass`, `listDocupass`, `getDocupass`, `deleteDocupass`
+- **ProfileAPI** — KYC profile create/list/get/update/delete/export
+- **Webhook** — `listWebhook`, `resendWebhook`, `deleteWebhook`
+- **Account** — `getAccount` (`/myaccount`)
 
 ## Scanner
 This category supports all scanning-related functions specifically used to initiate a new identity document scan & ID face verification transaction by uploading based64-encoded images.
@@ -172,6 +198,62 @@ try {
 
 ```
 
+## AML
+Screen names, businesses and document numbers against global sanctions / PEP / watchlists.
+```javascript
+import IdAnalyzer from "idanalyzer2"
+let {AML, APIError, InvalidArgumentException} = IdAnalyzer
+
+let a = new AML('GuH1YYus7ylJdWBDdhAiuSYXaAmQHZi3')
+a.throwApiException(true)
+let resp = await a.search("John Smith", "", 0, "US")        // POST /aml
+let respV3 = await a.searchV3("John Smith", "", 10, 1)       // POST /amlv3
+```
+
+## KYC Profiles (ProfileAPI)
+Create and manage server-side KYC profiles.
+```javascript
+import IdAnalyzer from "idanalyzer2"
+let {Profile, ProfileAPI} = IdAnalyzer
+
+let p = new ProfileAPI('GuH1YYus7ylJdWBDdhAiuSYXaAmQHZi3')
+p.throwApiException(true)
+
+let cfg = new Profile(Profile.SECURITY_MEDIUM)
+cfg.decisionTrigger(1, 1)
+let created = await p.createProfile("My Onboarding Profile", cfg)
+let profileId = created.profileId
+await p.updateProfile(profileId, "My Onboarding Profile (v2)", cfg)
+await p.getProfile(profileId)
+await p.listProfile()
+await p.exportProfile(profileId)
+await p.deleteProfile(profileId)
+```
+
+## Webhook
+List, resend and delete webhook delivery logs.
+```javascript
+import IdAnalyzer from "idanalyzer2"
+let {Webhook} = IdAnalyzer
+
+let w = new Webhook('GuH1YYus7ylJdWBDdhAiuSYXaAmQHZi3')
+w.throwApiException(true)
+let logs = await w.listWebhook()
+// await w.resendWebhook("<webhookId>")
+// await w.deleteWebhook("<webhookId>")
+```
+
+## Account
+Retrieve account quota and usage.
+```javascript
+import IdAnalyzer from "idanalyzer2"
+let {Account} = IdAnalyzer
+
+let acc = new Account('GuH1YYus7ylJdWBDdhAiuSYXaAmQHZi3')
+acc.throwApiException(true)
+console.log(await acc.getAccount())
+```
+
 ## Api Document
 [ID Analyzer Document](https://id-analyzer-v2.readme.io/docs/nodejs)
 
@@ -179,4 +261,4 @@ try {
 Check out **/demo** folder for more JS demos.
 
 ## SDK Reference
-Check out [ID Analyzer NodeJS Reference](https://idanalyzer.github.io/id-analyzer-nodejs/)
+Check out [ID Analyzer NodeJS Reference](https://idanalyzer.github.io/id-analyzer-v2-nodejs/)

--- a/demo/AMLDemo.js
+++ b/demo/AMLDemo.js
@@ -1,0 +1,22 @@
+import IdAnalyzer from "../index.js"
+let {AML, APIError, InvalidArgumentException} = IdAnalyzer
+import fs from "node:fs/promises"
+
+try {
+    let a = new AML('GuH1YYus7ylJdWBDdhAiuSYXaAmQHZi3')
+    a.throwApiException(true)
+
+    let resp = await a.search("John Smith", "", 0, "US")
+    await fs.writeFile("./amlSearch.json", JSON.stringify(resp))
+
+    let respV3 = await a.searchV3("John Smith", "", 10, 1)
+    await fs.writeFile("./amlSearchV3.json", JSON.stringify(respV3))
+} catch (e) {
+    if (e instanceof InvalidArgumentException) {
+        console.log("InvalidArgumentException => ", e.message)
+    } else if (e instanceof APIError) {
+        console.log("APIError => ", e.code, e.msg)
+    } else {
+        console.log("unknown error => ", e.message)
+    }
+}

--- a/demo/AccountDemo.js
+++ b/demo/AccountDemo.js
@@ -1,0 +1,19 @@
+import IdAnalyzer from "../index.js"
+let {Account, APIError, InvalidArgumentException} = IdAnalyzer
+import fs from "node:fs/promises"
+
+try {
+    let acc = new Account('GuH1YYus7ylJdWBDdhAiuSYXaAmQHZi3')
+    acc.throwApiException(true)
+
+    let resp = await acc.getAccount()
+    await fs.writeFile("./myAccount.json", JSON.stringify(resp))
+} catch (e) {
+    if (e instanceof InvalidArgumentException) {
+        console.log("InvalidArgumentException => ", e.message)
+    } else if (e instanceof APIError) {
+        console.log("APIError => ", e.code, e.msg)
+    } else {
+        console.log("unknown error => ", e.message)
+    }
+}

--- a/demo/ProfileDemo.js
+++ b/demo/ProfileDemo.js
@@ -1,0 +1,33 @@
+import IdAnalyzer from "../index.js"
+let {Profile, ProfileAPI, APIError, InvalidArgumentException} = IdAnalyzer
+import fs from "node:fs/promises"
+
+try {
+    let p = new ProfileAPI('GuH1YYus7ylJdWBDdhAiuSYXaAmQHZi3')
+    p.throwApiException(true)
+
+    let cfg = new Profile(Profile.SECURITY_MEDIUM)
+    cfg.decisionTrigger(1, 1)
+
+    let created = await p.createProfile("My Onboarding Profile", cfg)
+    await fs.writeFile("./createProfile.json", JSON.stringify(created))
+    let profileId = created.profileId
+
+    await p.updateProfile(profileId, "My Onboarding Profile (v2)", cfg)
+    let detail = await p.getProfile(profileId)
+    await fs.writeFile("./getProfile.json", JSON.stringify(detail))
+
+    let list = await p.listProfile()
+    await fs.writeFile("./listProfile.json", JSON.stringify(list))
+
+    await p.exportProfile(profileId)
+    await p.deleteProfile(profileId)
+} catch (e) {
+    if (e instanceof InvalidArgumentException) {
+        console.log("InvalidArgumentException => ", e.message)
+    } else if (e instanceof APIError) {
+        console.log("APIError => ", e.code, e.msg)
+    } else {
+        console.log("unknown error => ", e.message)
+    }
+}

--- a/demo/WebhookDemo.js
+++ b/demo/WebhookDemo.js
@@ -1,0 +1,22 @@
+import IdAnalyzer from "../index.js"
+let {Webhook, APIError, InvalidArgumentException} = IdAnalyzer
+import fs from "node:fs/promises"
+
+try {
+    let w = new Webhook('GuH1YYus7ylJdWBDdhAiuSYXaAmQHZi3')
+    w.throwApiException(true)
+
+    let logs = await w.listWebhook()
+    await fs.writeFile("./listWebhook.json", JSON.stringify(logs))
+
+    // await w.resendWebhook("<webhookId>")
+    // await w.deleteWebhook("<webhookId>")
+} catch (e) {
+    if (e instanceof InvalidArgumentException) {
+        console.log("InvalidArgumentException => ", e.message)
+    } else if (e instanceof APIError) {
+        console.log("APIError => ", e.code, e.msg)
+    } else {
+        console.log("unknown error => ", e.message)
+    }
+}

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,144 @@
+// Type definitions for idanalyzer2 (ID Analyzer API v2 Node.js SDK)
+// The package default-exports a namespace object containing every class.
+
+export type ApiResponse = Record<string, any>;
+
+export class APIError extends Error {
+  msg: string;
+  code: number | string;
+  constructor(message: string, code: number | string);
+}
+
+export class InvalidArgumentException extends Error {}
+
+declare class _ApiParent {
+  constructor(apiKey?: string | null);
+  apiKey: string;
+  config: Record<string, any>;
+  throwError: boolean;
+  getApiKey(customKey?: string | null): string | null;
+  setParam(key: string, value: any): void;
+  throwApiException(sw?: boolean): void;
+}
+
+export class Profile {
+  static SECURITY_NONE: string;
+  static SECURITY_LOW: string;
+  static SECURITY_MEDIUM: string;
+  static SECURITY_HIGH: string;
+  profileId: string;
+  profileOverride: Record<string, any>;
+  constructor(profileId: string);
+  loadFromJson(jsonStr?: string): void;
+  canvasSize(pixels: number): void;
+  orientationCorrection(enabled: boolean): void;
+  objectDetection(enabled: boolean): void;
+  AAMVABarcodeParsing(enabled: boolean): void;
+  saveResult(enableSaveTransaction: boolean, enableSaveTransactionImages: boolean): void;
+  outputImage(enableOutputImage: boolean, outputFormat?: string): void;
+  autoCrop(enableAutoCrop: boolean, enableAdvancedAutoCrop: boolean): void;
+  outputSize(pixels: number): void;
+  inferFullName(enabled: boolean): void;
+  splitFirstName(enabled: boolean): void;
+  transactionAuditReport(enabled: boolean): void;
+  setTimezone(timezone: string): void;
+  obscure(fieldKeys: string[]): void;
+  webhook(url?: string): void;
+  threshold(thresholdKey: string, thresholdValue: number): void;
+  decisionTrigger(reviewTrigger?: number, rejectTrigger?: number): void;
+  setWarning(code?: string, enabled?: boolean, reviewThreshold?: number, rejectThreshold?: number, weight?: number): void;
+  restrictDocumentCountry(countryCodes?: string): void;
+  restrictDocumentState(states?: string): void;
+  restrictDocumentType(documentType?: string): void;
+}
+
+export class Biometric extends _ApiParent {
+  setCustomData(customData: string): void;
+  setProfile(profile: Profile): void;
+  verifyFace(referenceFaceImage?: string, facePhoto?: string, faceVideo?: string): Promise<ApiResponse>;
+  verifyLiveness(facePhoto?: string, faceVideo?: string): Promise<ApiResponse>;
+}
+
+export class Contract extends _ApiParent {
+  generate(templateId?: string, _format?: string, transactionId?: string, fillData?: Record<string, any> | null): Promise<ApiResponse>;
+  listTemplate(order?: number, limit?: number, offset?: number, filterTemplateId?: string): Promise<ApiResponse>;
+  getTemplate(templateId?: string): Promise<ApiResponse>;
+  deleteTemplate(templateId?: string): Promise<ApiResponse>;
+  createTemplate(name?: string, content?: string, orientation?: string, timezone?: string, font?: string): Promise<ApiResponse>;
+  updateTemplate(templateId?: string, name?: string, content?: string, orientation?: string, timezone?: string, font?: string): Promise<ApiResponse>;
+}
+
+export class Scanner extends _ApiParent {
+  setUserIp(ip: string): void;
+  setCustomData(customData: string): void;
+  setContractOptions(templateId?: string, _format?: string, extraFillData?: Record<string, any> | null): void;
+  setProfile(profile: Profile): void;
+  verifyUserInformation(documentNumber?: string, fullName?: string, dob?: string, ageRange?: string, address?: string, postcode?: string): void;
+  restrictCountry(countryCodes?: string): void;
+  restrictState(states?: string): void;
+  restrictType(documentType?: string): void;
+  scan(documentFront?: string, documentBack?: string, facePhoto?: string, faceVideo?: string): Promise<ApiResponse>;
+  quickScan(documentFront?: string, documentBack?: string, cacheImage?: boolean): Promise<ApiResponse>;
+  veryQuickScan(documentFront?: string, documentBack?: string, cacheImage?: boolean): Promise<ApiResponse>;
+}
+
+export class Transaction extends _ApiParent {
+  getTransaction(transactionId?: string): Promise<ApiResponse>;
+  listTransaction(order?: number, limit?: number, offset?: number, createdAtMin?: number, createdAtMax?: number, filterCustomData?: string, filterDecision?: string, filterDocupass?: string, filterProfileId?: string): Promise<ApiResponse>;
+  updateTransaction(transactionId?: string, decision?: string): Promise<ApiResponse>;
+  deleteTransaction(transactionId?: string): Promise<ApiResponse>;
+  saveImage(imageToken?: string, destination?: string): Promise<void>;
+  saveFile(fileName?: string, destination?: string): Promise<void>;
+  exportTransaction(destination?: string, transactionId?: string[] | null, exportType?: string, ignoreUnrecognized?: boolean, ignoreDuplicate?: boolean, createdAtMin?: number, createdAtMax?: number, filterCustomData?: string, filterDecision?: string, filterDocupass?: string, filterProfileId?: string): Promise<void>;
+}
+
+export class Docupass extends _ApiParent {
+  listDocupass(order?: number, limit?: number, offset?: number): Promise<ApiResponse>;
+  createDocupass(profile?: string | null, mode?: number, contractFormat?: string, contractGenerate?: string, reusable?: boolean, contractPrefill?: string, contractSign?: string, customData?: string, language?: string, referenceDocument?: string | null, referenceDocumentBack?: string | null, referenceFace?: string | null, userPhone?: string, verifyAddress?: string, verifyAge?: string, verifyDOB?: string, verifyDocumentNumber?: string, verifyName?: string, verifyPostcode?: string): Promise<ApiResponse>;
+  getDocupass(reference?: string): Promise<ApiResponse>;
+  deleteDocupass(reference?: string): Promise<ApiResponse>;
+}
+
+export class AML extends _ApiParent {
+  search(name?: string, idNumber?: string, entity?: number, country?: string, database?: string[] | null, birthYear?: string): Promise<ApiResponse>;
+  searchV3(text?: string, id?: string, limit?: number, page?: number): Promise<ApiResponse>;
+}
+
+export class ProfileAPI extends _ApiParent {
+  listProfile(order?: number, limit?: number, offset?: number): Promise<ApiResponse>;
+  getProfile(profileId?: string): Promise<ApiResponse>;
+  createProfile(name?: string, profile?: Profile | Record<string, any> | null): Promise<ApiResponse>;
+  updateProfile(profileId?: string, name?: string, profile?: Profile | Record<string, any> | null): Promise<ApiResponse>;
+  deleteProfile(profileId?: string): Promise<ApiResponse>;
+  exportProfile(profileId?: string): Promise<ApiResponse>;
+}
+
+export class Webhook extends _ApiParent {
+  listWebhook(order?: number, limit?: number, offset?: number, event?: string, success?: number, createdAtMin?: string, createdAtMax?: string): Promise<ApiResponse>;
+  resendWebhook(webhookId?: string): Promise<ApiResponse>;
+  deleteWebhook(webhookId?: string): Promise<ApiResponse>;
+}
+
+export class Account extends _ApiParent {
+  getAccount(): Promise<ApiResponse>;
+}
+
+export function SetEndpoint(endpoint?: string): void;
+
+declare const IdAnalyzer: {
+  Profile: typeof Profile;
+  Biometric: typeof Biometric;
+  Contract: typeof Contract;
+  Scanner: typeof Scanner;
+  Transaction: typeof Transaction;
+  Docupass: typeof Docupass;
+  AML: typeof AML;
+  ProfileAPI: typeof ProfileAPI;
+  Webhook: typeof Webhook;
+  Account: typeof Account;
+  SetEndpoint: typeof SetEndpoint;
+  APIError: typeof APIError;
+  InvalidArgumentException: typeof InvalidArgumentException;
+};
+
+export default IdAnalyzer;

--- a/lib/common.js
+++ b/lib/common.js
@@ -20,7 +20,12 @@ export function ParseInput(str, allowCache=false) {
     if(str.length > 100) {
         return str
     }
-    return new InvalidArgumentException('Invalid input image, file not found or malformed URL.')
+    throw new InvalidArgumentException('Invalid input image, file not found or malformed URL.')
+}
+
+const REGION_ENDPOINTS = {
+    us: 'https://api2.idanalyzer.com',
+    eu: 'https://api2-eu.idanalyzer.com',
 }
 
 export function GetEndpoint(uri) {
@@ -32,12 +37,11 @@ export function GetEndpoint(uri) {
         return u.href
     }
 
-    let region = process.env.IDANALYZER_REGION
-    if(!region) {
-        return `https://v2-us1.idanalyzer.com/${uri}`
-    } else if (region.toLowerCase() === 'eu') {
-        return `https://api2-eu.idanalyzer.com/${uri}`
+    let region = (process.env.IDANALYZER_REGION || 'us').toLowerCase()
+    if(!(region in REGION_ENDPOINTS)) {
+        throw new InvalidArgumentException(`Invalid IDANALYZER_REGION '${region}', valid regions are: us, eu.`)
     }
+    return `${REGION_ENDPOINTS[region]}/${uri}`
 }
 
 export function SetEndpoint(endpoint='') {

--- a/lib/idanalyzer.js
+++ b/lib/idanalyzer.js
@@ -2,9 +2,7 @@ import {ApiExceptionHandle, GetEndpoint, ParseInput, SetEndpoint} from "./common
 
 import {APIError, InvalidArgumentException} from './exception.js'
 import * as fs from 'fs';
-import moment from "moment";
 import axios from "axios";
-import https from 'https';
 
 class _ApiParent {
     /**
@@ -12,9 +10,9 @@ class _ApiParent {
      * @param apiKey You API key
      */
     constructor(apiKey=null) {
-        this.apiKey = apiKey
         this.client_library = "nodejs-sdk"
-        if(this.apiKey === null) {
+        this.apiKey = this.getApiKey(apiKey)
+        if(!this.apiKey) {
             throw new Error("Please set API key via environment variable 'IDANALYZER_KEY'")
         }
         this.config = {
@@ -26,16 +24,12 @@ class _ApiParent {
                 'Content-Type': 'application/json',
                 'X-Api-Key': this.apiKey,
             },
-            withCredentials: true,
-            httpsAgent: new https.Agent({
-                rejectUnauthorized: false
-            }),
             validateStatus: () => true,
         })
     }
 
     getApiKey(customKey=null) {
-        return customKey ?? process.env.IDANALYZER_KEY
+        return customKey ?? process.env.IDANALYZER_KEY ?? null
     }
 
     /**
@@ -223,7 +217,7 @@ class Profile {
             throw new InvalidArgumentException('Invalid URL, the host does not appear to be a remote host.')
         }
 
-        if(urlinfo.protocol !== 'http' || urlinfo.protocol !== 'https')
+        if(urlinfo.protocol !== 'http:' && urlinfo.protocol !== 'https:')
             throw new InvalidArgumentException("Invalid URL, only http and https protocols are allowed.")
 
         this.profileOverride['webhook'] = url
@@ -578,11 +572,9 @@ class Contract extends _ApiParent {
             "timezone": timezone,
             "font": font,
         }
-        console.log(1)
         let resp = await this.http.post(GetEndpoint(`contract/${templateId}`), payload, {
             timeout: 60000,
         })
-        console.log(2)
         return ApiExceptionHandle(resp.data, this.throwError)
     }
 }
@@ -694,8 +686,9 @@ class Scanner extends _ApiParent {
         if(dob === "") {
             this.config['verifyDob'] = dob
         } else {
-            let t = moment(dob, 'YYYY/MM/DD')
-            if(t.isValid()) {
+            let dobReg = /^\d{4}\/\d{2}\/\d{2}$/
+            let t = new Date(dob)
+            if(dobReg.test(dob) && !isNaN(t.getTime())) {
                 this.config['verifyDob'] = dob
             } else {
                 throw new InvalidArgumentException('Invalid birthday format (YYYY/MM/DD)')
@@ -704,7 +697,7 @@ class Scanner extends _ApiParent {
         if(ageRange === "") {
             this.config['verifyAge'] = ageRange
         } else {
-            let ageVerifyReg = /^\d+-\d$/
+            let ageVerifyReg = /^\d+-\d+$/
             if(!ageVerifyReg.test(ageRange)) {
                 throw new InvalidArgumentException('Invalid age range format (minAge-maxAge)')
             }
@@ -801,6 +794,33 @@ class Scanner extends _ApiParent {
         })
         return ApiExceptionHandle(resp.data, this.throwError)
     }
+
+    /**
+     * Initiate a very quick (fast) identity document OCR scan by providing input images. Faster but less
+     * thorough than quickScan, useful for high-throughput OCR-only use cases.
+     *
+     * @param documentFront Front of Document (file path, base64 content or URL)
+     * @param documentBack Back of Document (file path, base64 content or URL)
+     * @param cacheImage Cache uploaded image(s) for 24 hours and obtain a cache reference for each image, the reference hash can be used to start standard scan transaction without re-uploading the file.
+     * @returns {Promise<*>}
+     */
+    async veryQuickScan(documentFront = "", documentBack = "", cacheImage = false) {
+        let payload = {
+            'saveFile': cacheImage,
+        }
+        if(documentFront === "") {
+            throw new InvalidArgumentException("Primary document image required.")
+        }
+        payload['document'] = ParseInput(documentFront)
+
+        if(documentBack !== "") {
+            payload['documentBack'] = ParseInput(documentBack)
+        }
+        let resp = await this.http.post(GetEndpoint('veryquickscan'), payload, {
+            timeout: 60000,
+        })
+        return ApiExceptionHandle(resp.data, this.throwError)
+    }
 }
 
 class Transaction extends _ApiParent {
@@ -876,7 +896,8 @@ class Transaction extends _ApiParent {
             payload['profileId'] = filterProfileId
         }
 
-        let resp = await this.http.get(GetEndpoint('transaction'), payload, {
+        let resp = await this.http.get(GetEndpoint('transaction'), {
+            params: payload,
             timeout: 60000,
         })
         return ApiExceptionHandle(resp.data, this.throwError)
@@ -1058,7 +1079,24 @@ class Docupass extends _ApiParent {
             "limit": limit,
             "offset": offset,
         }
-        let resp = await this.http.get(GetEndpoint('docupass'), payload, {
+        let resp = await this.http.get(GetEndpoint('docupass'), {
+            params: payload,
+            timeout: 30000,
+        })
+        return ApiExceptionHandle(resp.data, this.throwError)
+    }
+
+    /**
+     * Retrieve a single Docupass record by reference.
+     *
+     * @param reference Docupass reference ID
+     * @returns {Promise<*>}
+     */
+    async getDocupass(reference = '') {
+        if(reference === '') {
+            throw new InvalidArgumentException("'reference' is required.")
+        }
+        let resp = await this.http.get(GetEndpoint(`docupass/${reference}`), {
             timeout: 30000,
         })
         return ApiExceptionHandle(resp.data, this.throwError)
@@ -1155,4 +1193,214 @@ class Docupass extends _ApiParent {
 }
 
 
-export {Profile, Biometric, Contract, Scanner, Transaction, Docupass, SetEndpoint, APIError, InvalidArgumentException};
+class AML extends _ApiParent {
+    /**
+     * @param apiKey Your API key
+     */
+    constructor(apiKey = null) {
+        super(apiKey);
+    }
+
+    /**
+     * Search the AML database (v1 endpoint).
+     *
+     * @param name Search AML database with person's name or business name
+     * @param idNumber Search AML database with document number
+     * @param entity 0=Person, 1=Corporation/Legal Entity
+     * @param country Two digit ISO country code to filter by country/nationality
+     * @param database Optional array of databases to search, e.g. ["us_ofac","eu_fsf"]. If omitted all databases are searched.
+     * @param birthYear Filter by year of birth
+     * @returns {Promise<*>}
+     */
+    async search(name = "", idNumber = "", entity = 0, country = "", database = null, birthYear = "") {
+        if(name === "" && idNumber === "") {
+            throw new InvalidArgumentException("Either 'name' or 'idNumber' is required.")
+        }
+        let payload = {'entity': entity}
+        if(name !== "") payload['name'] = name
+        if(idNumber !== "") payload['idNumber'] = idNumber
+        if(country !== "") payload['country'] = country
+        if(birthYear !== "") payload['birthYear'] = birthYear
+        if(database && database.length > 0) payload['database'] = database
+
+        let resp = await this.http.post(GetEndpoint('aml'), payload, {timeout: 30000})
+        return ApiExceptionHandle(resp.data, this.throwError)
+    }
+
+    /**
+     * Search the AML database (v3 endpoint). Provide either a free-text query or one or more entity IDs.
+     *
+     * @param text Full-text query (name, alias, document/passport/tax/registration number, etc.)
+     * @param id One or more AML entity IDs separated by comma or newline (max 50)
+     * @param limit Number of results to return per page
+     * @param page Result page number
+     * @returns {Promise<*>}
+     */
+    async searchV3(text = "", id = "", limit = 0, page = 0) {
+        if(text === "" && id === "") {
+            throw new InvalidArgumentException("Either 'text' or 'id' is required.")
+        }
+        let payload = {}
+        if(text !== "") payload['text'] = text
+        if(id !== "") payload['id'] = id
+        if(limit > 0) payload['limit'] = limit
+        if(page > 0) payload['page'] = page
+
+        let resp = await this.http.post(GetEndpoint('amlv3'), payload, {timeout: 30000})
+        return ApiExceptionHandle(resp.data, this.throwError)
+    }
+}
+
+class ProfileAPI extends _ApiParent {
+    /**
+     * @param apiKey Your API key
+     */
+    constructor(apiKey = null) {
+        super(apiKey);
+    }
+
+    static _profileBody(name, profile) {
+        let body = {}
+        if(name !== "") body['name'] = name
+        if(profile) {
+            if(profile instanceof Profile) {
+                Object.assign(body, profile.profileOverride)
+            } else if(typeof profile === 'object') {
+                Object.assign(body, profile)
+            } else {
+                throw new InvalidArgumentException("'profile' should be a Profile object or plain object.")
+            }
+        }
+        return body
+    }
+
+    /**
+     * List KYC profiles.
+     * @returns {Promise<*>}
+     */
+    async listProfile(order = -1, limit = 10, offset = 0) {
+        if(order !== -1 && order !== 1) {
+            throw new InvalidArgumentException("'order' should be integer of 1 or -1.")
+        }
+        let resp = await this.http.get(GetEndpoint('profile'), {
+            params: {order, limit, offset},
+            timeout: 30000,
+        })
+        return ApiExceptionHandle(resp.data, this.throwError)
+    }
+
+    /**
+     * Retrieve a single KYC profile.
+     * @returns {Promise<*>}
+     */
+    async getProfile(profileId = "") {
+        if(profileId === "") throw new InvalidArgumentException("'profileId' required.")
+        let resp = await this.http.get(GetEndpoint(`profile/${profileId}`), {timeout: 30000})
+        return ApiExceptionHandle(resp.data, this.throwError)
+    }
+
+    /**
+     * Create a new KYC profile.
+     * @param name Profile name
+     * @param profile A Profile object (its overrides become the profile config) or a plain object
+     * @returns {Promise<*>}
+     */
+    async createProfile(name = "", profile = null) {
+        if(name === "") throw new InvalidArgumentException("Profile name required.")
+        let resp = await this.http.post(GetEndpoint('profile'), ProfileAPI._profileBody(name, profile), {timeout: 30000})
+        return ApiExceptionHandle(resp.data, this.throwError)
+    }
+
+    /**
+     * Update an existing KYC profile.
+     * @returns {Promise<*>}
+     */
+    async updateProfile(profileId = "", name = "", profile = null) {
+        if(profileId === "") throw new InvalidArgumentException("'profileId' required.")
+        let resp = await this.http.put(GetEndpoint(`profile/${profileId}`), ProfileAPI._profileBody(name, profile), {timeout: 30000})
+        return ApiExceptionHandle(resp.data, this.throwError)
+    }
+
+    /**
+     * Delete a KYC profile.
+     * @returns {Promise<*>}
+     */
+    async deleteProfile(profileId = "") {
+        if(profileId === "") throw new InvalidArgumentException("'profileId' required.")
+        let resp = await this.http.delete(GetEndpoint(`profile/${profileId}`), {timeout: 30000})
+        return ApiExceptionHandle(resp.data, this.throwError)
+    }
+
+    /**
+     * Export a KYC profile (GET /export/profile/{id}).
+     * @returns {Promise<*>}
+     */
+    async exportProfile(profileId = "") {
+        if(profileId === "") throw new InvalidArgumentException("'profileId' required.")
+        let resp = await this.http.get(GetEndpoint(`export/profile/${profileId}`), {timeout: 60000})
+        return ApiExceptionHandle(resp.data, this.throwError)
+    }
+}
+
+class Webhook extends _ApiParent {
+    /**
+     * @param apiKey Your API key
+     */
+    constructor(apiKey = null) {
+        super(apiKey);
+    }
+
+    /**
+     * List webhook delivery logs.
+     * @returns {Promise<*>}
+     */
+    async listWebhook(order = -1, limit = 10, offset = 0, event = "", success = -1, createdAtMin = "", createdAtMax = "") {
+        let payload = {order, limit, offset}
+        if(event !== "") payload['event'] = event
+        if(success === 0 || success === 1) payload['success'] = success
+        if(createdAtMin !== "") payload['createdAtMin'] = createdAtMin
+        if(createdAtMax !== "") payload['createdAtMax'] = createdAtMax
+        let resp = await this.http.get(GetEndpoint('webhook'), {params: payload, timeout: 30000})
+        return ApiExceptionHandle(resp.data, this.throwError)
+    }
+
+    /**
+     * Resend a webhook delivery.
+     * @returns {Promise<*>}
+     */
+    async resendWebhook(webhookId = "") {
+        if(webhookId === "") throw new InvalidArgumentException("'webhookId' required.")
+        let resp = await this.http.post(GetEndpoint(`webhook/${webhookId}`), {}, {timeout: 30000})
+        return ApiExceptionHandle(resp.data, this.throwError)
+    }
+
+    /**
+     * Delete a webhook delivery log.
+     * @returns {Promise<*>}
+     */
+    async deleteWebhook(webhookId = "") {
+        if(webhookId === "") throw new InvalidArgumentException("'webhookId' required.")
+        let resp = await this.http.delete(GetEndpoint(`webhook/${webhookId}`), {timeout: 30000})
+        return ApiExceptionHandle(resp.data, this.throwError)
+    }
+}
+
+class Account extends _ApiParent {
+    /**
+     * @param apiKey Your API key
+     */
+    constructor(apiKey = null) {
+        super(apiKey);
+    }
+
+    /**
+     * Retrieve current account profile, quota and usage.
+     * @returns {Promise<*>}
+     */
+    async getAccount() {
+        let resp = await this.http.get(GetEndpoint('myaccount'), {timeout: 30000})
+        return ApiExceptionHandle(resp.data, this.throwError)
+    }
+}
+
+export {Profile, Biometric, Contract, Scanner, Transaction, Docupass, AML, ProfileAPI, Webhook, Account, SetEndpoint, APIError, InvalidArgumentException};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,36 +1,171 @@
 {
   "name": "idanalyzer2",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "idanalyzer2",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
-        "axios": "^0.21.4",
-        "moment": "^2.29.1"
+        "axios": "^1.7.7"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
-    "node_modules/axios": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.14.0"
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
+      "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.16.0",
+        "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
+        "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.14.9",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
-      "integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",
           "url": "https://github.com/sponsors/RubenVerborgh"
         }
       ],
+      "license": "MIT",
       "engines": {
         "node": ">=4.0"
       },
@@ -40,33 +175,382 @@
         }
       }
     },
-    "node_modules/moment": {
-      "version": "2.29.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
-      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==",
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
       "engines": {
-        "node": "*"
+        "node": ">= 6"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     }
   },
   "dependencies": {
-    "axios": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+    "agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
       "requires": {
-        "follow-redirects": "^1.14.0"
+        "debug": "4"
+      }
+    },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
+    "axios": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
+      "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
+      "requires": {
+        "follow-redirects": "^1.16.0",
+        "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
+        "proxy-from-env": "^2.1.0"
+      }
+    },
+    "call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "requires": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      }
+    },
+    "combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "requires": {
+        "delayed-stream": "~1.0.0"
+      }
+    },
+    "debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "requires": {
+        "ms": "^2.1.3"
+      }
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
+    },
+    "dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "requires": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      }
+    },
+    "es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="
+    },
+    "es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="
+    },
+    "es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "requires": {
+        "es-errors": "^1.3.0"
+      }
+    },
+    "es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "requires": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
       }
     },
     "follow-redirects": {
-      "version": "1.14.9",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
-      "integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w=="
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw=="
     },
-    "moment": {
-      "version": "2.29.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
-      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
+    "form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      }
+    },
+    "function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="
+    },
+    "get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "requires": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      }
+    },
+    "get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "requires": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      }
+    },
+    "gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="
+    },
+    "has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="
+    },
+    "has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "requires": {
+        "has-symbols": "^1.0.3"
+      }
+    },
+    "hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "requires": {
+        "function-bind": "^1.1.2"
+      }
+    },
+    "https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "requires": {
+        "agent-base": "6",
+        "debug": "4"
+      }
+    },
+    "math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="
+    },
+    "mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
+    },
+    "mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "requires": {
+        "mime-db": "1.52.0"
+      }
+    },
+    "ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+    },
+    "proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,8 +1,12 @@
 {
   "name": "idanalyzer2",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "ID Analyzer API V2 client library, scan and verify global passport, driver license and identification card.",
   "main": "index.js",
+  "types": "index.d.ts",
+  "engines": {
+    "node": ">=18"
+  },
   "directories": {
     "doc": "docs",
     "lib": "lib",
@@ -40,8 +44,7 @@
   },
   "homepage": "https://www.idanalyzer.com",
   "dependencies": {
-    "axios": "^0.21.4",
-    "moment": "^2.29.1"
+    "axios": "^1.7.7"
   },
   "type": "module"
 }


### PR DESCRIPTION
Brings the Node.js SDK to full v2 parity with the PHP reference SDK, fixes security/dependency issues, and adds TypeScript types.

## Security / Fixed
- **Removed `httpsAgent: { rejectUnauthorized: false }`** — TLS cert verification was disabled on every request (silent MITM exposure).
- **axios `^0.21.4` → `^1.7.7`** (0.21 line has known CVEs incl. CVE-2023-45857); **removed deprecated `moment`**.
- **Base URL** default `v2-us1.idanalyzer.com` (single node, no Cloudflare/LB/HA) → load-balanced **`api2.idanalyzer.com`**. EU unchanged.
- Unknown `IDANALYZER_REGION` now throws instead of returning `undefined`.
- Fixed `Profile.webhook()` protocol guard (always-true `||`, missing `:` suffix → rejected every URL).
- Fixed `listTransaction`/`listDocupass` passing query params as the axios **body** (filters/pagination were never sent).
- Fixed age-range regex `^\d+-\d$` → `^\d+-\d+$`; constructor now honours `IDANALYZER_KEY`; removed `console.log` debug.

## Added (parity)
- `Scanner.veryQuickScan` → `POST /veryquickscan`
- `AML.search` (`/aml`, + optional `birthYear`) and `AML.searchV3` (`/amlv3`)
- `Docupass.getDocupass` → `GET /docupass/{reference}`
- `ProfileAPI` (KYC profile CRUD + export), `Webhook` (list/resend/delete), `Account.getAccount` (`/myaccount`)
- **Bundled TypeScript definitions** (`index.d.ts`); `engines.node >= 18`; demos for the new classes

Bumps `1.0.2 → 1.1.0`. `node --check` + an ESM import smoke test (all 13 exports present, new methods callable on axios 1.16.1) pass. Per-endpoint `verifyDOB`/`verifyDob` casing preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)