### PR TITLE
README: KB doc links + fix stale DocuPass image

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 
 # ID Analyzer NodeJS
-This is a Javascript library for [ID Analyzer Identity Verification APIs](https://www.idanalyzer.com), though all the APIs can be called with without the library using simple HTTP requests as outlined in the [documentation](https://id-analyzer-v2.readme.io), you can use this library to accelerate server-side development.
+This is a Javascript library for [ID Analyzer Identity Verification APIs](https://www.idanalyzer.com), though all the APIs can be called with without the library using simple HTTP requests as outlined in the [documentation](https://idanalyzer.helptal.com/help), you can use this library to accelerate server-side development.
 
 We strongly discourage users to connect to ID Analyzer API endpoint directly  from client-side applications that will be distributed to end user, such as mobile app, or in-browser JavaScript. Your API key could be easily compromised, and if you are storing your customer's information inside Vault they could use your API key to fetch all your user details. Therefore, the best practice is always to implement a client side connection to your server, and call our APIs from the server-side.
 
@@ -136,7 +136,7 @@ try {
 
 ## Docupass
 This category supports all rapid user verification based on the ids and the face images provided.
-![DocuPass Screen](https://www.idanalyzer.com/img/docupassliveflow.jpg)
+![DocuPass Screen](https://www.idanalyzer.com/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Fdocupass-hero.0~_7a8exuldcn.webp&w=1080&q=75)
 ```javascript
 import IdAnalyzer from "idanalyzer2"
 let {Profile, Scanner, SetEndpoint, APIError, InvalidArgumentException, Docupass} = IdAnalyzer
@@ -255,10 +255,10 @@ console.log(await acc.getAccount())
 ```
 
 ## Api Document
-[ID Analyzer Document](https://id-analyzer-v2.readme.io/docs/nodejs)
+[ID Analyzer Document](https://idanalyzer.helptal.com/help)
 
 ## Demo
 Check out **/demo** folder for more JS demos.
 
 ## SDK Reference
-Check out [ID Analyzer NodeJS Reference](https://idanalyzer.github.io/id-analyzer-v2-nodejs/)
+Check out [ID Analyzer NodeJS Reference](https://idanalyzer.helptal.com/help/nodejs)


### PR DESCRIPTION
Points the README documentation/reference links to the Helptal KB (https://idanalyzer.helptal.com/help and the per-language article) and replaces the stale DocuPass hero image with the current marketing asset. README-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)