### PR TITLE
ci: bump publish workflow to Node 26

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,7 +23,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '26'
           registry-url: 'https://registry.npmjs.org'
 
       # Trusted publishing requires npm >= 11.5.1


### PR DESCRIPTION
Bumps the npm publish workflow's setup-node from Node 22 to Node 26.

🤖 Generated with [Claude Code](https://claude.com/claude-code)