### PR TITLE
docs: neutral endpoint wording (remove infra details)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Full API v2 surface parity, security fixes, modern deps, and TypeScript types.
   CVE-2023-45857) and **removed the deprecated `moment` dependency** (date check is
   now a small regex + `Date`).
 - **Base URL** default `v2-us1.idanalyzer.com` (single node, no Cloudflare/LB/HA) →
-  load-balanced **`api2.idanalyzer.com`**. EU unchanged (`api2-eu` via `IDANALYZER_REGION=eu`).
+  **`api2.idanalyzer.com`**. EU unchanged (`api2-eu` via `IDANALYZER_REGION=eu`).
 - Unknown `IDANALYZER_REGION` now throws `InvalidArgumentException` instead of
   returning `undefined` (which broke every request).
 - Fixed `Profile.webhook()` protocol guard (`!== 'http' || !== 'https'` was always

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ TypeScript definitions are bundled (`index.d.ts`) — no `@types` package needed
 
 ## Authentication & region
 
-Pass your API key to each client, or set the `IDANALYZER_KEY` environment variable. The SDK targets the load-balanced US fleet (`https://api2.idanalyzer.com`) by default; set `IDANALYZER_REGION=eu` for the EU fleet (`https://api2-eu.idanalyzer.com`). An unrecognized region throws `InvalidArgumentException`. For on-premise [ID Fort](https://www.idanalyzer.com) deployments, call `SetEndpoint('https://your-host/')`.
+Pass your API key to each client, or set the `IDANALYZER_KEY` environment variable. The SDK targets the US endpoint (`https://api2.idanalyzer.com`) by default; set `IDANALYZER_REGION=eu` for the EU endpoint (`https://api2-eu.idanalyzer.com`). An unrecognized region throws `InvalidArgumentException`. For on-premise [ID Fort](https://www.idanalyzer.com) deployments, call `SetEndpoint('https://your-host/')`.
 
 ## Quick start
 


### PR DESCRIPTION
Removes internal architecture wording ('load-balanced … fleet') from docs, package metadata and source comments; uses neutral 'endpoint' language. Public hostnames unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)