### PR TITLE
docs: complete inline API documentation

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,130 +1,630 @@
 // Type definitions for idanalyzer2 (ID Analyzer API v2 Node.js SDK)
 // The package default-exports a namespace object containing every class.
 
+/**
+ * A decoded JSON object returned by the ID Analyzer API. The exact shape
+ * depends on the endpoint; see https://developer.idanalyzer.com for per-endpoint
+ * response schemas.
+ */
 export type ApiResponse = Record<string, any>;
 
+/**
+ * Error thrown when the ID Analyzer API returns an error payload and exception
+ * throwing has been enabled via {@link Biometric.throwApiException} (or the same
+ * method on any other client).
+ */
 export class APIError extends Error {
+  /** Human-readable error message from the API. */
   msg: string;
+  /** Machine-readable error code from the API. */
   code: number | string;
+  /**
+   * @param message Human-readable error message from the API.
+   * @param code Machine-readable error code from the API.
+   */
   constructor(message: string, code: number | string);
 }
 
+/** Error thrown when an argument passed to an SDK method is missing or invalid. */
 export class InvalidArgumentException extends Error {}
 
+/**
+ * Internal base class shared by all API client classes. Handles API key
+ * resolution, the shared request configuration object and exception behaviour.
+ * Not intended to be instantiated directly.
+ */
 declare class _ApiParent {
+  /**
+   * @param apiKey Your API key. If omitted, the `IDANALYZER_KEY` environment
+   *   variable is used.
+   */
   constructor(apiKey?: string | null);
+  /** The resolved API key. */
   apiKey: string;
+  /** The shared request configuration object sent with each API call. */
   config: Record<string, any>;
+  /** Whether an {@link APIError} is thrown when the API returns an error. */
   throwError: boolean;
+  /**
+   * Resolve the API key, preferring the provided value and falling back to the
+   * `IDANALYZER_KEY` environment variable.
+   * @param customKey Explicitly supplied API key.
+   * @returns The resolved API key, or `null` if none is available.
+   */
   getApiKey(customKey?: string | null): string | null;
+  /**
+   * Set an arbitrary API parameter without using the built-in helper methods.
+   * @param key Parameter key.
+   * @param value Parameter value.
+   */
   setParam(key: string, value: any): void;
+  /**
+   * Control whether an {@link APIError} is thrown when the API response
+   * contains an error message.
+   * @param sw `true` to throw on API errors, `false` to return the raw error.
+   */
   throwApiException(sw?: boolean): void;
 }
 
+/**
+ * KYC Profile builder. A profile defines how documents are processed and
+ * validated; reference a preset (`SECURITY_*`) or custom profile ID and layer
+ * per-request overrides via the setter methods. Pass the result to
+ * {@link Scanner.setProfile} or {@link Biometric.setProfile}.
+ */
 export class Profile {
+  /** Preset profile applying no validation. */
   static SECURITY_NONE: string;
+  /** Preset profile applying low-strictness validation. */
   static SECURITY_LOW: string;
+  /** Preset profile applying medium-strictness validation. */
   static SECURITY_MEDIUM: string;
+  /** Preset profile applying high-strictness validation. */
   static SECURITY_HIGH: string;
+  /** The resolved profile ID (preset or custom). */
   profileId: string;
+  /** Per-request profile overrides accumulated by the setter methods. */
   profileOverride: Record<string, any>;
+  /**
+   * @param profileId Custom profile ID or a preset profile (`security_none`,
+   *   `security_low`, `security_medium`, `security_high`). `SECURITY_NONE` is
+   *   used if left blank.
+   */
   constructor(profileId: string);
+  /**
+   * Replace the profile overrides with the contents of a JSON string.
+   * @param jsonStr JSON string containing profile information.
+   */
   loadFromJson(jsonStr?: string): void;
+  /**
+   * Maximum canvas dimension in pixels; larger inputs are scaled down before
+   * processing. Set 0 to disable resizing.
+   * @param pixels Maximum canvas dimension in pixels.
+   */
   canvasSize(pixels: number): void;
+  /**
+   * Correct image orientation for rotated images.
+   * @param enabled Whether to enable automatic orientation correction.
+   */
   orientationCorrection(enabled: boolean): void;
+  /**
+   * Automatically detect and return the locations of signature, document and face.
+   * @param enabled Whether to enable object detection.
+   */
   objectDetection(enabled: boolean): void;
+  /**
+   * Parse AAMVA barcodes for US/CA ID/DL.
+   * @param enabled Whether to enable AAMVA barcode parsing.
+   */
   AAMVABarcodeParsing(enabled: boolean): void;
+  /**
+   * Control whether scan results and output images are saved on the cloud.
+   * @param enableSaveTransaction Whether the scan transaction result is saved.
+   * @param enableSaveTransactionImages Whether output images are also saved.
+   */
   saveResult(enableSaveTransaction: boolean, enableSaveTransactionImages: boolean): void;
+  /**
+   * Control whether the output image is returned in the API response.
+   * @param enableOutputImage Whether to return the output image.
+   * @param outputFormat Output image format, "url" or "base64".
+   */
   outputImage(enableOutputImage: boolean, outputFormat?: string): void;
+  /**
+   * Crop the image before saving and returning output.
+   * @param enableAutoCrop Whether to auto-crop the document from the image.
+   * @param enableAdvancedAutoCrop Whether to enable advanced (perspective-corrected) cropping.
+   */
   autoCrop(enableAutoCrop: boolean, enableAdvancedAutoCrop: boolean): void;
+  /**
+   * Maximum width/height in pixels for output and saved image.
+   * @param pixels Maximum width/height in pixels.
+   */
   outputSize(pixels: number): void;
+  /**
+   * Generate a full name field from parsed first/middle/last name.
+   * @param enabled Whether to infer the full name field.
+   */
   inferFullName(enabled: boolean): void;
+  /**
+   * If the first name has more than one word, move the rest into middle name.
+   * @param enabled Whether to split a multi-word first name.
+   */
   splitFirstName(enabled: boolean): void;
+  /**
+   * Generate a detailed PDF audit report for every transaction.
+   * @param enabled Whether to generate an audit report per transaction.
+   */
   transactionAuditReport(enabled: boolean): void;
+  /**
+   * Set the timezone used in audit reports.
+   * @param timezone TZ database name (e.g. "America/New_York"); UTC if blank.
+   */
   setTimezone(timezone: string): void;
+  /**
+   * Redact and blur the given data fields before transaction storage.
+   * @param fieldKeys Array of data field keys to redact.
+   */
   obscure(fieldKeys: string[]): void;
+  /**
+   * Set a remote URL to receive Docupass verification and scan results.
+   * @param url Remote webhook URL (http/https, non-localhost host).
+   */
   webhook(url?: string): void;
+  /**
+   * Set the validation threshold of a specified component.
+   * @param thresholdKey Threshold component key.
+   * @param thresholdValue Threshold value.
+   */
   threshold(thresholdKey: string, thresholdValue: number): void;
+  /**
+   * Set the review/reject decision trigger scores.
+   * @param reviewTrigger Score at/above which the decision becomes "review".
+   * @param rejectTrigger Score at/above which the decision becomes "reject".
+   */
   decisionTrigger(reviewTrigger?: number, rejectTrigger?: number): void;
+  /**
+   * Enable/disable and fine-tune how a validation component affects the decision.
+   * @param code Document Validation Component Code / Warning Code.
+   * @param enabled Whether the component is enabled.
+   * @param reviewThreshold Confidence threshold contributing to the review score.
+   * @param rejectThreshold Confidence threshold contributing to the reject score.
+   * @param weight Weight added to review/reject scores when validation fails.
+   */
   setWarning(code?: string, enabled?: boolean, reviewThreshold?: number, rejectThreshold?: number, weight?: number): void;
+  /**
+   * Restrict accepted documents by issuing country.
+   * @param countryCodes ISO ALPHA-2 country codes separated by comma.
+   */
   restrictDocumentCountry(countryCodes?: string): void;
+  /**
+   * Restrict accepted documents by issuing state.
+   * @param states State full names or abbreviations separated by comma.
+   */
   restrictDocumentState(states?: string): void;
+  /**
+   * Restrict accepted documents by type.
+   * @param documentType P: Passport, D: Driver's License, I: Identity Card.
+   */
   restrictDocumentType(documentType?: string): void;
 }
 
+/**
+ * Biometric API client. Performs 1:1 face verification and standalone liveness
+ * checks.
+ */
 export class Biometric extends _ApiParent {
+  /**
+   * Set an arbitrary string to save with the transaction (e.g. a reference number).
+   * @param customData Arbitrary string to store alongside the transaction.
+   */
   setCustomData(customData: string): void;
+  /**
+   * Set the KYC profile to use.
+   * @param profile A {@link Profile} object.
+   */
   setProfile(profile: Profile): void;
+  /**
+   * Perform 1:1 face verification against a reference face image.
+   * @param referenceFaceImage Reference face image (file path, base64, URL or cache reference).
+   * @param facePhoto Face photo (file path, base64, URL or cache reference).
+   * @param faceVideo Face video (file path, base64 or URL), used if `facePhoto` is empty.
+   * @returns The parsed API response.
+   */
   verifyFace(referenceFaceImage?: string, facePhoto?: string, faceVideo?: string): Promise<ApiResponse>;
+  /**
+   * Perform a standalone liveness check on a selfie photo or video.
+   * @param facePhoto Face photo (file path, base64, URL or cache reference).
+   * @param faceVideo Face video (file path, base64 or URL), used if `facePhoto` is empty.
+   * @returns The parsed API response.
+   */
   verifyLiveness(facePhoto?: string, faceVideo?: string): Promise<ApiResponse>;
 }
 
+/**
+ * Contract API client. Manages contract templates and generates filled
+ * documents (PDF/DOCX/HTML) from templates and transaction data.
+ */
 export class Contract extends _ApiParent {
+  /**
+   * Generate a document using a template and transaction data.
+   * @param templateId Template ID.
+   * @param _format Output format: PDF, DOCX or HTML.
+   * @param transactionId Fill the template with data from this transaction.
+   * @param fillData Key-value pairs to autofill dynamic fields.
+   * @returns The parsed API response.
+   */
   generate(templateId?: string, _format?: string, transactionId?: string, fillData?: Record<string, any> | null): Promise<ApiResponse>;
+  /**
+   * Retrieve a list of contract templates.
+   * @param order Sort by newest(-1) or oldest(1).
+   * @param limit Number of items per call.
+   * @param offset Start index.
+   * @param filterTemplateId Filter by template ID.
+   * @returns The parsed API response.
+   */
   listTemplate(order?: number, limit?: number, offset?: number, filterTemplateId?: string): Promise<ApiResponse>;
+  /**
+   * Get a single contract template.
+   * @param templateId Template ID.
+   * @returns The parsed API response.
+   */
   getTemplate(templateId?: string): Promise<ApiResponse>;
+  /**
+   * Delete a contract template.
+   * @param templateId Template ID.
+   * @returns The parsed API response.
+   */
   deleteTemplate(templateId?: string): Promise<ApiResponse>;
+  /**
+   * Create a new contract template.
+   * @param name Template name.
+   * @param content Template HTML content.
+   * @param orientation 0=Portrait(Default), 1=Landscape.
+   * @param timezone Template timezone.
+   * @param font Template font.
+   * @returns The parsed API response.
+   */
   createTemplate(name?: string, content?: string, orientation?: string, timezone?: string, font?: string): Promise<ApiResponse>;
+  /**
+   * Update an existing contract template.
+   * @param templateId Template ID.
+   * @param name Template name.
+   * @param content Template HTML content.
+   * @param orientation 0=Portrait(Default), 1=Landscape.
+   * @param timezone Template timezone.
+   * @param font Template font.
+   * @returns The parsed API response.
+   */
   updateTemplate(templateId?: string, name?: string, content?: string, orientation?: string, timezone?: string, font?: string): Promise<ApiResponse>;
 }
 
+/**
+ * Scanner API client. Initiates identity document scans (full KYC, plus
+ * quick/very-quick OCR-only variants) and configures verification, document
+ * restrictions and contract generation.
+ */
 export class Scanner extends _ApiParent {
+  /**
+   * Pass the user IP to check the ID issuing country against it.
+   * @param ip User IP address; the HTTP connection IP is used if empty.
+   */
   setUserIp(ip: string): void;
+  /**
+   * Set an arbitrary string to save with the transaction.
+   * @param customData Arbitrary string to store alongside the transaction.
+   */
   setCustomData(customData: string): void;
+  /**
+   * Automatically generate a contract document using values parsed from the ID.
+   * @param templateId Up to 5 contract template IDs (comma-separated); empty disables generation.
+   * @param _format Output format: PDF, DOCX or HTML.
+   * @param extraFillData Key-value pairs to autofill dynamic fields.
+   */
   setContractOptions(templateId?: string, _format?: string, extraFillData?: Record<string, any> | null): void;
+  /**
+   * Set the KYC profile to use.
+   * @param profile A {@link Profile} object.
+   */
   setProfile(profile: Profile): void;
+  /**
+   * Check that customer information matches the uploaded document.
+   * @param documentNumber Document or ID number.
+   * @param fullName Full name.
+   * @param dob Date of birth in YYYY/MM/DD.
+   * @param ageRange Age range, e.g. "18-40".
+   * @param address Address.
+   * @param postcode Postcode.
+   */
   verifyUserInformation(documentNumber?: string, fullName?: string, dob?: string, ageRange?: string, address?: string, postcode?: string): void;
+  /**
+   * Restrict accepted documents by issuing country.
+   * @param countryCodes ISO ALPHA-2 country codes separated by comma.
+   */
   restrictCountry(countryCodes?: string): void;
+  /**
+   * Restrict accepted documents by issuing state.
+   * @param states State full names or abbreviations separated by comma.
+   */
   restrictState(states?: string): void;
+  /**
+   * Restrict accepted documents by type.
+   * @param documentType P: Passport, D: Driver's License, I: Identity Card.
+   */
   restrictType(documentType?: string): void;
+  /**
+   * Initiate a new identity document scan & ID face verification transaction.
+   * @param documentFront Front of document (file path, base64, URL or cache reference).
+   * @param documentBack Back of document (file path, base64, URL or cache reference).
+   * @param facePhoto Face photo (file path, base64, URL or cache reference).
+   * @param faceVideo Face video (file path, base64 or URL), used if `facePhoto` is empty.
+   * @returns The parsed API response.
+   */
   scan(documentFront?: string, documentBack?: string, facePhoto?: string, faceVideo?: string): Promise<ApiResponse>;
+  /**
+   * Initiate a quick OCR-only document scan.
+   * @param documentFront Front of document (file path, base64 or URL).
+   * @param documentBack Back of document (file path, base64 or URL).
+   * @param cacheImage Cache uploaded image(s) for 24 hours and return a cache reference.
+   * @returns The parsed API response.
+   */
   quickScan(documentFront?: string, documentBack?: string, cacheImage?: boolean): Promise<ApiResponse>;
+  /**
+   * Initiate a very quick (fast, less thorough) OCR-only document scan.
+   * @param documentFront Front of document (file path, base64 or URL).
+   * @param documentBack Back of document (file path, base64 or URL).
+   * @param cacheImage Cache uploaded image(s) for 24 hours and return a cache reference.
+   * @returns The parsed API response.
+   */
   veryQuickScan(documentFront?: string, documentBack?: string, cacheImage?: boolean): Promise<ApiResponse>;
 }
 
+/**
+ * Transaction API client. Retrieves, lists, updates and deletes transactions,
+ * and downloads transaction images, files and archive exports.
+ */
 export class Transaction extends _ApiParent {
+  /**
+   * Retrieve a single transaction record.
+   * @param transactionId Transaction ID.
+   * @returns The parsed API response.
+   */
   getTransaction(transactionId?: string): Promise<ApiResponse>;
+  /**
+   * Retrieve a list of transaction history.
+   * @param order Sort by newest(-1) or oldest(1).
+   * @param limit Number of items per call.
+   * @param offset Start index.
+   * @param createdAtMin Created-after UNIX timestamp.
+   * @param createdAtMax Created-before UNIX timestamp.
+   * @param filterCustomData Filter by customData field.
+   * @param filterDecision Filter by decision (accept, review, reject).
+   * @param filterDocupass Filter by Docupass reference.
+   * @param filterProfileId Filter by KYC Profile ID.
+   * @returns The parsed API response.
+   */
   listTransaction(order?: number, limit?: number, offset?: number, createdAtMin?: number, createdAtMax?: number, filterCustomData?: string, filterDecision?: string, filterDocupass?: string, filterProfileId?: string): Promise<ApiResponse>;
+  /**
+   * Update a transaction's decision (relayed to the webhook if set).
+   * @param transactionId Transaction ID.
+   * @param decision New decision (accept, review or reject).
+   * @returns The parsed API response.
+   */
   updateTransaction(transactionId?: string, decision?: string): Promise<ApiResponse>;
+  /**
+   * Delete a transaction.
+   * @param transactionId Transaction ID.
+   * @returns The parsed API response.
+   */
   deleteTransaction(transactionId?: string): Promise<ApiResponse>;
+  /**
+   * Download a transaction image to the local filesystem.
+   * @param imageToken Image token from the transaction API response.
+   * @param destination Full destination path including file name (e.g. a .jpg file).
+   * @returns Resolves once the image has been written to disk.
+   */
   saveImage(imageToken?: string, destination?: string): Promise<void>;
+  /**
+   * Download a transaction file to the local filesystem.
+   * @param fileName Secured file name obtained from the transaction.
+   * @param destination Full destination path including file name.
+   * @returns Resolves once the file has been written to disk.
+   */
   saveFile(fileName?: string, destination?: string): Promise<void>;
+  /**
+   * Download a transaction archive export to the local filesystem.
+   * @param destination Full destination path including file name (e.g. a .zip file).
+   * @param transactionId Export only the specified transaction IDs; `null` exports all matching.
+   * @param exportType Export format, 'csv' or 'json'.
+   * @param ignoreUnrecognized Ignore unrecognized documents.
+   * @param ignoreDuplicate Ignore duplicated entries.
+   * @param createdAtMin Created-after UNIX timestamp.
+   * @param createdAtMax Created-before UNIX timestamp.
+   * @param filterCustomData Filter by customData field.
+   * @param filterDecision Filter by decision (accept, review, reject).
+   * @param filterDocupass Filter by Docupass reference.
+   * @param filterProfileId Filter by KYC Profile ID.
+   * @returns Resolves once the archive has been downloaded to disk (if available).
+   */
   exportTransaction(destination?: string, transactionId?: string[] | null, exportType?: string, ignoreUnrecognized?: boolean, ignoreDuplicate?: boolean, createdAtMin?: number, createdAtMax?: number, filterCustomData?: string, filterDecision?: string, filterDocupass?: string, filterProfileId?: string): Promise<void>;
 }
 
+/**
+ * Docupass API client. Creates, lists, retrieves and deletes Docupass
+ * verification sessions (hosted ID verification links/forms).
+ */
 export class Docupass extends _ApiParent {
+  /**
+   * Retrieve a list of Docupass sessions.
+   * @param order Sort by newest(-1) or oldest(1).
+   * @param limit Number of items per call.
+   * @param offset Start index.
+   * @returns The parsed API response.
+   */
   listDocupass(order?: number, limit?: number, offset?: number): Promise<ApiResponse>;
+  /**
+   * Create a new Docupass verification session.
+   * @param profile KYC Profile ID to apply (required).
+   * @param mode Docupass verification mode.
+   * @param contractFormat Generated contract format ('pdf', 'docx' or 'html').
+   * @param contractGenerate Contract template ID(s) to auto-generate on completion.
+   * @param reusable Whether the Docupass link can be reused by multiple users.
+   * @param contractPrefill Data used to prefill the generated contract.
+   * @param contractSign Contract signing configuration.
+   * @param customData Arbitrary string to store alongside the transaction.
+   * @param language Display language for the Docupass page.
+   * @param referenceDocument Reference document front image to verify against.
+   * @param referenceDocumentBack Reference document back image to verify against.
+   * @param referenceFace Reference face image to verify against.
+   * @param userPhone User phone number.
+   * @param verifyAddress Address to verify against the submitted document.
+   * @param verifyAge Age range to verify against the submitted document.
+   * @param verifyDOB Date of birth (YYYY/MM/DD) to verify.
+   * @param verifyDocumentNumber Document/ID number to verify.
+   * @param verifyName Full name to verify.
+   * @param verifyPostcode Postcode to verify.
+   * @returns The parsed API response.
+   */
   createDocupass(profile?: string | null, mode?: number, contractFormat?: string, contractGenerate?: string, reusable?: boolean, contractPrefill?: string, contractSign?: string, customData?: string, language?: string, referenceDocument?: string | null, referenceDocumentBack?: string | null, referenceFace?: string | null, userPhone?: string, verifyAddress?: string, verifyAge?: string, verifyDOB?: string, verifyDocumentNumber?: string, verifyName?: string, verifyPostcode?: string): Promise<ApiResponse>;
+  /**
+   * Retrieve a single Docupass record by reference.
+   * @param reference Docupass reference ID.
+   * @returns The parsed API response.
+   */
   getDocupass(reference?: string): Promise<ApiResponse>;
+  /**
+   * Delete a Docupass session by reference.
+   * @param reference Docupass reference ID.
+   * @returns The parsed API response.
+   */
   deleteDocupass(reference?: string): Promise<ApiResponse>;
 }
 
+/**
+ * AML (Anti-Money-Laundering) API client. Searches sanction, PEP and watchlist
+ * databases via the v1 and v3 search endpoints.
+ */
 export class AML extends _ApiParent {
+  /**
+   * Search the AML database (v1 endpoint).
+   * @param name Person or business name.
+   * @param idNumber Document number.
+   * @param entity 0=Person, 1=Corporation/Legal Entity.
+   * @param country Two-digit ISO country code to filter by.
+   * @param database Optional array of databases to search; all if omitted.
+   * @param birthYear Filter by year of birth.
+   * @returns The parsed API response.
+   */
   search(name?: string, idNumber?: string, entity?: number, country?: string, database?: string[] | null, birthYear?: string): Promise<ApiResponse>;
+  /**
+   * Search the AML database (v3 endpoint). Provide a free-text query or entity IDs.
+   * @param text Full-text query (name, alias, document/tax/registration number, etc.).
+   * @param id One or more AML entity IDs separated by comma or newline (max 50).
+   * @param limit Number of results per page (0 uses the API default).
+   * @param page Result page number (0 uses the API default).
+   * @returns The parsed API response.
+   */
   searchV3(text?: string, id?: string, limit?: number, page?: number): Promise<ApiResponse>;
 }
 
+/**
+ * Profile API client. Manages stored KYC profiles on your account
+ * (list, retrieve, create, update, delete and export).
+ */
 export class ProfileAPI extends _ApiParent {
+  /**
+   * List KYC profiles.
+   * @param order Sort by newest(-1) or oldest(1).
+   * @param limit Number of items per call.
+   * @param offset Start index.
+   * @returns The parsed API response.
+   */
   listProfile(order?: number, limit?: number, offset?: number): Promise<ApiResponse>;
+  /**
+   * Retrieve a single KYC profile.
+   * @param profileId KYC profile ID.
+   * @returns The parsed API response.
+   */
   getProfile(profileId?: string): Promise<ApiResponse>;
+  /**
+   * Create a new KYC profile.
+   * @param name Profile name.
+   * @param profile A {@link Profile} object (its overrides become the config) or a plain object.
+   * @returns The parsed API response.
+   */
   createProfile(name?: string, profile?: Profile | Record<string, any> | null): Promise<ApiResponse>;
+  /**
+   * Update an existing KYC profile.
+   * @param profileId KYC profile ID.
+   * @param name New profile name.
+   * @param profile A {@link Profile} object (its overrides become the config) or a plain object.
+   * @returns The parsed API response.
+   */
   updateProfile(profileId?: string, name?: string, profile?: Profile | Record<string, any> | null): Promise<ApiResponse>;
+  /**
+   * Delete a KYC profile.
+   * @param profileId KYC profile ID.
+   * @returns The parsed API response.
+   */
   deleteProfile(profileId?: string): Promise<ApiResponse>;
+  /**
+   * Export a KYC profile.
+   * @param profileId KYC profile ID.
+   * @returns The parsed API response.
+   */
   exportProfile(profileId?: string): Promise<ApiResponse>;
 }
 
+/**
+ * Webhook API client. Lists webhook delivery logs and allows resending or
+ * deleting individual delivery records.
+ */
 export class Webhook extends _ApiParent {
+  /**
+   * List webhook delivery logs.
+   * @param order Sort by newest(-1) or oldest(1).
+   * @param limit Number of items per call.
+   * @param offset Start index.
+   * @param event Filter by event type.
+   * @param success Filter by delivery success: 1=success, 0=failure, -1=no filter.
+   * @param createdAtMin List deliveries created after this timestamp.
+   * @param createdAtMax List deliveries created before this timestamp.
+   * @returns The parsed API response.
+   */
   listWebhook(order?: number, limit?: number, offset?: number, event?: string, success?: number, createdAtMin?: string, createdAtMax?: string): Promise<ApiResponse>;
+  /**
+   * Resend a webhook delivery.
+   * @param webhookId Webhook delivery ID.
+   * @returns The parsed API response.
+   */
   resendWebhook(webhookId?: string): Promise<ApiResponse>;
+  /**
+   * Delete a webhook delivery log.
+   * @param webhookId Webhook delivery ID.
+   * @returns The parsed API response.
+   */
   deleteWebhook(webhookId?: string): Promise<ApiResponse>;
 }
 
+/** Account API client. Retrieves the current account profile, quota and usage. */
 export class Account extends _ApiParent {
+  /**
+   * Retrieve the current account profile, quota and usage.
+   * @returns The parsed API response.
+   */
   getAccount(): Promise<ApiResponse>;
 }
 
+/**
+ * Override the API base endpoint for all subsequent requests, bypassing the
+ * region-based default. Pass an empty string to clear the override.
+ * @param endpoint Fully-qualified base URL to use as the API endpoint.
+ */
 export function SetEndpoint(endpoint?: string): void;
 
+/**
+ * The default-exported namespace object containing every public SDK class and
+ * helper.
+ */
 declare const IdAnalyzer: {
   Profile: typeof Profile;
   Biometric: typeof Biometric;

--- a/index.js
+++ b/index.js
@@ -1,3 +1,13 @@
+/**
+ * ID Analyzer API v2 Node.js SDK entry point.
+ *
+ * Re-exports every public class and helper from the SDK as a single namespace
+ * object: `Profile`, `Biometric`, `Contract`, `Scanner`, `Transaction`,
+ * `Docupass`, `AML`, `ProfileAPI`, `Webhook`, `Account`, `SetEndpoint`,
+ * `APIError` and `InvalidArgumentException`.
+ *
+ * @module idanalyzer2
+ */
 import * as IdAnalyzer from './lib/idanalyzer.js'
 
 export default IdAnalyzer

--- a/lib/common.js
+++ b/lib/common.js
@@ -1,8 +1,28 @@
 import * as fs from 'fs';
 import {APIError, InvalidArgumentException} from "./exception.js";
 
+/**
+ * Module-level override for the API base endpoint. Empty means use the
+ * region-based default. Set via {@link SetEndpoint}.
+ *
+ * @private
+ * @type {string}
+ */
 var _endpoint = ''
 
+/**
+ * Normalize an image/file input into the value expected by the API. The input
+ * may be a cache reference ("ref:..."), a URL, a local file path (which is read
+ * and base64-encoded), or an already-base64-encoded/long string.
+ *
+ * @param {string} str Input value: a "ref:" cache reference, a URL, a local
+ *   file path, or a base64-encoded image string.
+ * @param {boolean} [allowCache=false] If `true`, a value starting with "ref:"
+ *   is returned unchanged as a cache reference.
+ * @returns {string} The URL, cache reference, or base64-encoded file contents.
+ * @throws {InvalidArgumentException} If the input is neither a valid URL, an
+ *   existing file, nor a sufficiently long string to be treated as inline data.
+ */
 export function ParseInput(str, allowCache=false) {
     if(allowCache && str.slice(0, 4) === 'ref:') {
         return str
@@ -23,11 +43,27 @@ export function ParseInput(str, allowCache=false) {
     throw new InvalidArgumentException('Invalid input image, file not found or malformed URL.')
 }
 
+/**
+ * Map of supported region codes to their API base URLs.
+ *
+ * @private
+ * @type {Object<string, string>}
+ */
 const REGION_ENDPOINTS = {
     us: 'https://api2.idanalyzer.com',
     eu: 'https://api2-eu.idanalyzer.com',
 }
 
+/**
+ * Resolve a request URI into a fully-qualified URL. Absolute URLs are returned
+ * unchanged. Otherwise the URI is resolved against the override endpoint set by
+ * {@link SetEndpoint}, or, if none is set, against the base URL for the region
+ * given by the `IDANALYZER_REGION` environment variable (defaults to "us").
+ *
+ * @param {string} uri An absolute URL, or a path relative to the API base URL.
+ * @returns {string} The fully-qualified request URL.
+ * @throws {InvalidArgumentException} If `IDANALYZER_REGION` is set to an unsupported region.
+ */
 export function GetEndpoint(uri) {
     if (uri.slice(0, 4).toLowerCase() === 'http')
         return uri
@@ -44,11 +80,29 @@ export function GetEndpoint(uri) {
     return `${REGION_ENDPOINTS[region]}/${uri}`
 }
 
+/**
+ * Override the API base endpoint for all subsequent requests, bypassing the
+ * region-based default. Pass an empty string to clear the override and revert
+ * to region-based resolution.
+ *
+ * @param {string} [endpoint=''] Fully-qualified base URL to use as the API endpoint.
+ * @returns {void}
+ * @throws {TypeError} If `endpoint` is not a valid URL.
+ */
 export function SetEndpoint(endpoint='') {
     let i = new URL('', endpoint)
     _endpoint = endpoint
 }
 
+/**
+ * Inspect a decoded API response and optionally raise on an error payload.
+ *
+ * @param {Object<string, *>} respJson The decoded JSON response body.
+ * @param {boolean} throwError If `true` and the response contains an `error`
+ *   object, an {@link APIError} is thrown instead of returning the response.
+ * @returns {Object<string, *>} The original response object (when not throwing).
+ * @throws {APIError} If `throwError` is `true` and the response contains an error.
+ */
 export function ApiExceptionHandle(respJson, throwError) {
     if ('error' in respJson && throwError) {
         throw new APIError(respJson['error']['message'], respJson['error']['code'])

--- a/lib/exception.js
+++ b/lib/exception.js
@@ -1,8 +1,32 @@
+/**
+ * Error thrown when the ID Analyzer API returns an error payload and exception
+ * throwing is enabled via {@link _ApiParent#throwApiException}.
+ *
+ * @extends Error
+ */
 export class APIError extends Error {
+    /**
+     * @param {string} message Human-readable error message from the API.
+     * @param {number|string} code Machine-readable error code from the API.
+     */
     constructor(message, code) {
         super(message);
+        /**
+         * Human-readable error message from the API.
+         * @type {string}
+         */
         this.msg = message
+        /**
+         * Machine-readable error code from the API.
+         * @type {number|string}
+         */
         this.code = code
     }
 }
+
+/**
+ * Error thrown when an argument passed to an SDK method is missing or invalid.
+ *
+ * @extends Error
+ */
 export class InvalidArgumentException extends Error {}

--- a/lib/idanalyzer.js
+++ b/lib/idanalyzer.js
@@ -4,10 +4,29 @@ import {APIError, InvalidArgumentException} from './exception.js'
 import * as fs from 'fs';
 import axios from "axios";
 
+/**
+ * A decoded JSON object returned by the ID Analyzer API. The exact shape
+ * depends on the endpoint; see the API reference at
+ * https://developer.idanalyzer.com for per-endpoint response schemas.
+ *
+ * @typedef {Object<string, *>} ApiResponse
+ */
+
+/**
+ * Internal base class shared by all API client classes. Handles API key
+ * resolution, the shared request configuration object and the underlying
+ * axios HTTP client. Not intended to be instantiated directly.
+ *
+ * @private
+ */
 class _ApiParent {
     /**
+     * Create a new API client. The API key is resolved from the explicit
+     * argument, falling back to the `IDANALYZER_KEY` environment variable.
      *
-     * @param apiKey You API key
+     * @param {string|null} [apiKey=null] Your API key. If omitted, the
+     *   `IDANALYZER_KEY` environment variable is used.
+     * @throws {Error} If no API key can be resolved.
      */
     constructor(apiKey=null) {
         this.client_library = "nodejs-sdk"
@@ -28,6 +47,13 @@ class _ApiParent {
         })
     }
 
+    /**
+     * Resolve the API key, preferring the provided value and falling back to
+     * the `IDANALYZER_KEY` environment variable.
+     *
+     * @param {string|null} [customKey=null] Explicitly supplied API key.
+     * @returns {string|null} The resolved API key, or `null` if none is available.
+     */
     getApiKey(customKey=null) {
         return customKey ?? process.env.IDANALYZER_KEY ?? null
     }
@@ -35,8 +61,9 @@ class _ApiParent {
     /**
      * Set an API parameter and its value, this function allows you to set any API parameter without using the built-in functions
      *
-     * @param key Parameter key
-     * @param value Parameter value
+     * @param {string} key Parameter key
+     * @param {*} value Parameter value
+     * @returns {void}
      */
     setParam(key, value) {
         this.config[key] = value
@@ -45,17 +72,31 @@ class _ApiParent {
     /**
      * Whether an exception should be thrown if API response contains an error message
      *
-     * @param sw
+     * @param {boolean} [sw=false] Set to `true` to throw an {@link APIError}
+     *   when the API response contains an error, or `false` to return the raw
+     *   error response instead.
+     * @returns {void}
      */
     throwApiException(sw=false) {
         this.throwError = sw
     }
 }
 
+/**
+ * KYC Profile builder. A profile defines how documents are processed and
+ * validated. You may reference a preset profile (one of the `SECURITY_*`
+ * constants) or a custom profile ID, and optionally layer per-request
+ * overrides on top using the setter methods on this class. The resulting
+ * object is passed to {@link Scanner#setProfile} or {@link Biometric#setProfile}.
+ */
 class Profile {
+    /** Preset profile applying no validation. @type {string} */
     static SECURITY_NONE = "security_none"
+    /** Preset profile applying low-strictness validation. @type {string} */
     static SECURITY_LOW = "security_low"
+    /** Preset profile applying medium-strictness validation. @type {string} */
     static SECURITY_MEDIUM = "security_medium"
+    /** Preset profile applying high-strictness validation. @type {string} */
     static SECURITY_HIGH = "security_high"
     /**
      * Initialize KYC Profile
@@ -71,7 +112,8 @@ class Profile {
     /**
      * Set profile configuration with provided JSON string
      *
-     * @param {string} jsonStr JSON string containing profile information.
+     * @param {string} [jsonStr='{}'] JSON string containing profile information.
+     * @returns {void}
      */
     loadFromJson(jsonStr = '{}') {
         this.profileOverride = JSON.parse(jsonStr)
@@ -80,7 +122,8 @@ class Profile {
     /**
      * Canvas Size in pixels, input image larger than this size will be scaled down before further processing, reduced image size will improve inference time but reduce result accuracy. Set 0 to disable image resizing.
      *
-     * @param {number} pixels
+     * @param {number} pixels Maximum canvas dimension in pixels. Set 0 to disable resizing.
+     * @returns {void}
      */
     canvasSize(pixels) {
         this.profileOverride['canvasSize'] = pixels
@@ -89,7 +132,8 @@ class Profile {
     /**
      * Correct image orientation for rotated images
      *
-     * @param {boolean} enabled
+     * @param {boolean} enabled Whether to enable automatic orientation correction.
+     * @returns {void}
      */
     orientationCorrection(enabled) {
         this.profileOverride['orientationCorrection'] = enabled
@@ -98,7 +142,8 @@ class Profile {
     /**
      * Enable to automatically detect and return the locations of signature, document and face.
      *
-     * @param {boolean} enabled
+     * @param {boolean} enabled Whether to enable object detection.
+     * @returns {void}
      */
     objectDetection(enabled) {
         this.profileOverride['objectDetection'] = enabled
@@ -107,7 +152,8 @@ class Profile {
     /**
      * Enable to parse AAMVA barcode for US/CA ID/DL. Disable this to improve performance if you are not planning on scanning ID/DL from US or Canada.
      *
-     * @param {boolean} enabled
+     * @param {boolean} enabled Whether to enable AAMVA barcode parsing.
+     * @returns {void}
      */
     AAMVABarcodeParsing(enabled) {
         this.profileOverride['AAMVABarcodeParsing'] = enabled
@@ -116,8 +162,9 @@ class Profile {
     /**
      * Whether scan transaction results and output images should be saved on cloud
      *
-     * @param enableSaveTransaction
-     * @param enableSaveTransactionImages
+     * @param {boolean} enableSaveTransaction Whether the scan transaction result should be saved on the cloud.
+     * @param {boolean} enableSaveTransactionImages Whether the output images should also be saved on the cloud.
+     * @returns {void}
      */
     saveResult(enableSaveTransaction, enableSaveTransactionImages) {
         this.profileOverride['saveResult'] = enableSaveTransaction
@@ -128,8 +175,9 @@ class Profile {
     /**
      * Whether to return output image as part of API response
      *
-     * @param enableOutputImage
-     * @param outputFormat
+     * @param {boolean} enableOutputImage Whether to return the output image in the API response.
+     * @param {string} [outputFormat="url"] Output image format, either "url" or "base64".
+     * @returns {void}
      */
     outputImage(enableOutputImage, outputFormat="url") {
         this.profileOverride['outputImage'] = enableOutputImage
@@ -140,8 +188,9 @@ class Profile {
     /**
      * Crop image before saving and returning output
      *
-     * @param enableAutoCrop
-     * @param enableAdvancedAutoCrop
+     * @param {boolean} enableAutoCrop Whether to automatically crop the document from the image.
+     * @param {boolean} enableAdvancedAutoCrop Whether to enable advanced (perspective-corrected) auto cropping.
+     * @returns {void}
      */
     autoCrop(enableAutoCrop, enableAdvancedAutoCrop) {
         this.profileOverride['crop'] = enableAutoCrop
@@ -151,7 +200,8 @@ class Profile {
     /**
      * Maximum width/height in pixels for output and saved image.
      *
-     * @param pixels
+     * @param {number} pixels Maximum width/height in pixels for the output and saved image.
+     * @returns {void}
      */
     outputSize(pixels) {
         this.profileOverride['outputSize'] = pixels
@@ -160,7 +210,8 @@ class Profile {
     /**
      * Generate a full name field using parsed first name, middle name and last name.
      *
-     * @param enabled
+     * @param {boolean} enabled Whether to infer the full name field.
+     * @returns {void}
      */
     inferFullName(enabled) {
         this.profileOverride['inferFullName'] = enabled
@@ -169,7 +220,8 @@ class Profile {
     /**
      * If first name contains more than one word, move second word onwards into middle name field.
      *
-     * @param enabled
+     * @param {boolean} enabled Whether to split a multi-word first name into first and middle name.
+     * @returns {void}
      */
     splitFirstName(enabled) {
         this.profileOverride['splitFirstName'] = enabled
@@ -178,7 +230,8 @@ class Profile {
     /**
      * Enable to generate a detailed PDF audit report for every transaction.
      *
-     * @param enabled
+     * @param {boolean} enabled Whether to generate a PDF audit report for every transaction.
+     * @returns {void}
      */
     transactionAuditReport(enabled) {
         this.profileOverride['transactionAuditReport'] = enabled
@@ -187,7 +240,8 @@ class Profile {
     /**
      * Set timezone for audit reports. If left blank, UTC will be used. Refer to https://en.wikipedia.org/wiki/List_of_tz_database_time_zones TZ database name list.
      *
-     * @param timezone
+     * @param {string} timezone TZ database name (e.g. "America/New_York"). UTC is used if left blank.
+     * @returns {void}
      */
     setTimezone(timezone) {
         this.profileOverride['timezone'] = timezone
@@ -196,7 +250,8 @@ class Profile {
     /**
      * A list of data fields key to be redacted before transaction storage, these fields will also be blurred from output & saved image.
      *
-     * @param fieldKeys
+     * @param {string[]} fieldKeys Array of data field keys to redact and blur.
+     * @returns {void}
      */
     obscure(fieldKeys) {
         this.profileOverride['obscure'] = fieldKeys
@@ -205,7 +260,9 @@ class Profile {
     /**
      * Enter a server URL to listen for Docupass verification and scan transaction results
      *
-     * @param url
+     * @param {string} [url="https://www.example.com/webhook.php"] Remote webhook URL. Must be a valid http/https URL pointing at a non-localhost host.
+     * @returns {void}
+     * @throws {InvalidArgumentException} If the URL is malformed, points to localhost, or uses a non-http(s) protocol.
      */
     webhook(url="https://www.example.com/webhook.php") {
         let reg = new RegExp(this.URL_VALIDATION_REGEX)
@@ -226,8 +283,9 @@ class Profile {
     /**
      * Set validation threshold of a specified component
      *
-     * @param thresholdKey
-     * @param thresholdValue
+     * @param {string} thresholdKey Threshold component key.
+     * @param {number} thresholdValue Threshold value for the specified component.
+     * @returns {void}
      */
     threshold(thresholdKey, thresholdValue) {
         if (!this.profileOverride['thresholds'])
@@ -238,8 +296,9 @@ class Profile {
     /**
      * Set decision trigger value
      *
-     * @param reviewTrigger {number} If the final total review score is equal to or greater than this value, the final KYC decision will be "review"
-     * @param rejectTrigger {number} If the final total review score is equal to or greater than this value, the final KYC decision will be "reject". Reject has higher priority than review.
+     * @param {number} [reviewTrigger=1] If the final total review score is equal to or greater than this value, the final KYC decision will be "review".
+     * @param {number} [rejectTrigger=1] If the final total review score is equal to or greater than this value, the final KYC decision will be "reject". Reject has higher priority than review.
+     * @returns {void}
      */
     decisionTrigger(reviewTrigger = 1, rejectTrigger = 1) {
         this.profileOverride['decisionTrigger'] = {
@@ -251,11 +310,12 @@ class Profile {
     /**
      * Enable/Disable and fine-tune how each Document Validation Component affects the final decision.
      *
-     * @param code {string} Document Validation Component Code / Warning Code
-     * @param enabled {boolean} Enable the current Document Validation Component
-     * @param reviewThreshold {number} If the current validation has failed to pass, and the specified number is greater than or equal to zero, and the confidence of this warning is greater than or equal to the specified value, the "total review score" will be added by the weight value.
-     * @param rejectThreshold {number} If the current validation has failed to pass, and the specified number is greater than or equal to zero, and the confidence of this warning is greater than or equal to the specified value, the "total reject score" will be added by the weight value.
-     * @param weight {number} Weight to add to the total review and reject score if the validation has failed to pass.
+     * @param {string} [code="UNRECOGNIZED_DOCUMENT"] Document Validation Component Code / Warning Code
+     * @param {boolean} [enabled=true] Enable the current Document Validation Component
+     * @param {number} [reviewThreshold=-1] If the current validation has failed to pass, and the specified number is greater than or equal to zero, and the confidence of this warning is greater than or equal to the specified value, the "total review score" will be added by the weight value.
+     * @param {number} [rejectThreshold=0] If the current validation has failed to pass, and the specified number is greater than or equal to zero, and the confidence of this warning is greater than or equal to the specified value, the "total reject score" will be added by the weight value.
+     * @param {number} [weight=1] Weight to add to the total review and reject score if the validation has failed to pass.
+     * @returns {void}
      */
     setWarning(code = "UNRECOGNIZED_DOCUMENT", enabled = true, reviewThreshold = -1,
                rejectThreshold = 0, weight = 1) {
@@ -272,7 +332,8 @@ class Profile {
     /**
      * Check if the document was issued by specified countries. Separate multiple values with comma. For example "US,CA" would accept documents from the United States and Canada.
      *
-     * @param countryCodes {string} ISO ALPHA-2 Country Code separated by comma
+     * @param {string} [countryCodes="US,CA,UK"] ISO ALPHA-2 Country Code separated by comma
+     * @returns {void}
      */
     restrictDocumentCountry(countryCodes = "US,CA,UK") {
         if(this.profileOverride['acceptedDocuments']) {
@@ -284,7 +345,8 @@ class Profile {
     /**
      * Check if the document was issued by specified state. Separate multiple values with comma. For example "CA,TX" would accept documents from California and Texas.
      *
-     * @param states {string} State full name or abbreviation separated by comma
+     * @param {string} [states="CA,TX"] State full name or abbreviation separated by comma
+     * @returns {void}
      */
     restrictDocumentState(states = "CA,TX") {
         if(this.profileOverride['acceptedDocuments']) {
@@ -296,7 +358,8 @@ class Profile {
     /**
      * Check if the document was one of the specified types. For example, "PD" would accept both passport and driver license.
      *
-     * @param documentType {string} P: Passport, D: Driver's License, I: Identity Card
+     * @param {string} [documentType="DIP"] P: Passport, D: Driver's License, I: Identity Card
+     * @returns {void}
      */
     restrictDocumentType(documentType = "DIP") {
         if(this.profileOverride['acceptedDocuments']) {
@@ -306,10 +369,18 @@ class Profile {
     }
 }
 
+/**
+ * Biometric API client. Performs 1:1 face verification and standalone
+ * liveness checks against the ID Analyzer biometric endpoints.
+ *
+ * @augments _ApiParent
+ */
 class Biometric extends _ApiParent {
     /**
+     * Create a new Biometric API client.
      *
-     * @param apiKey You API key
+     * @param {string|null} [apiKey=null] Your API key. If omitted, the
+     *   `IDANALYZER_KEY` environment variable is used.
      */
     constructor(apiKey = null) {
         super(apiKey);
@@ -323,7 +394,8 @@ class Biometric extends _ApiParent {
     /**
      * Set an arbitrary string you wish to save with the transaction. e.g Internal customer reference number
      *
-     * @param customData
+     * @param {string} customData Arbitrary string to store alongside the transaction.
+     * @returns {void}
      */
     setCustomData(customData) {
         this.config['customData'] = customData
@@ -332,7 +404,9 @@ class Biometric extends _ApiParent {
     /**
      * Set KYC Profile
      *
-     * @param profile KYCProfile object
+     * @param {Profile} profile KYC {@link Profile} object.
+     * @returns {void}
+     * @throws {InvalidArgumentException} If `profile` is not a {@link Profile} instance.
      */
     setProfile(profile) {
         if (profile instanceof Profile) {
@@ -350,10 +424,11 @@ class Biometric extends _ApiParent {
     /**
      * Perform 1:1 face verification using selfie photo or selfie video, against a reference face image.
      *
-     * @param referenceFaceImage Front of Document (file path, base64 content, url, or cache reference)
-     * @param facePhoto Face Photo (file path, base64 content or URL, or cache reference)
-     * @param faceVideo Face Video (file path, base64 content or URL)
-     * @returns {Promise<*>}
+     * @param {string} [referenceFaceImage=''] Reference face image / front of document (file path, base64 content, URL, or cache reference).
+     * @param {string} [facePhoto=""] Face Photo (file path, base64 content or URL, or cache reference). Provide either this or `faceVideo`.
+     * @param {string} [faceVideo=""] Face Video (file path, base64 content or URL). Used if `facePhoto` is empty.
+     * @returns {Promise<ApiResponse>} The parsed API response.
+     * @throws {InvalidArgumentException} If no profile is configured, the reference image is missing, or no verification face is supplied.
      */
     async verifyFace(referenceFaceImage = '', facePhoto = "", faceVideo = "") {
         if (this.config['profile'] === '') {
@@ -381,9 +456,10 @@ class Biometric extends _ApiParent {
     /**
      * Perform standalone liveness check on a selfie photo or video.
      *
-     * @param facePhoto Face Photo (file path, base64 content or URL, or cache reference)
-     * @param faceVideo Face Video (file path, base64 content or URL)
-     * @returns {Promise<*>}
+     * @param {string} [facePhoto=""] Face Photo (file path, base64 content or URL, or cache reference). Provide either this or `faceVideo`.
+     * @param {string} [faceVideo=""] Face Video (file path, base64 content or URL). Used if `facePhoto` is empty.
+     * @returns {Promise<ApiResponse>} The parsed API response.
+     * @throws {InvalidArgumentException} If no profile is configured or no face image/video is supplied.
      */
     async verifyLiveness(facePhoto = "", faceVideo = "") {
         if (this.config['profile'] === '') {
@@ -405,10 +481,18 @@ class Biometric extends _ApiParent {
     }
 }
 
+/**
+ * Contract API client. Manages contract templates and generates filled
+ * documents (PDF/DOCX/HTML) from templates and transaction data.
+ *
+ * @augments _ApiParent
+ */
 class Contract extends _ApiParent {
     /**
+     * Create a new Contract API client.
      *
-     * @param apiKey You API key
+     * @param {string|null} [apiKey=null] Your API key. If omitted, the
+     *   `IDANALYZER_KEY` environment variable is used.
      */
     constructor(apiKey=null) {
         super(apiKey);
@@ -417,11 +501,12 @@ class Contract extends _ApiParent {
     /**
      * Generate document using template and transaction data
      *
-     * @param templateId Template ID
-     * @param _format PDF, DOCX or HTML
-     * @param transactionId Fill the template with data from specified transaction
-     * @param {*} fillData - Array data in key-value pairs to autofill dynamic fields, data from user ID will be used first in case of a conflict. For example, passing {"myparameter":"abc"} would fill %{myparameter} in contract template with "abc".
-     * @returns {Promise<*>}
+     * @param {string} [templateId=''] Template ID.
+     * @param {string} [_format='PDF'] Output format: PDF, DOCX or HTML.
+     * @param {string} [transactionId=''] Fill the template with data from the specified transaction.
+     * @param {Object<string, *>|null} [fillData=null] Key-value pairs to autofill dynamic fields. Data from the user ID is used first in case of a conflict. For example, passing `{"myparameter":"abc"}` would fill `%{myparameter}` in the contract template with "abc".
+     * @returns {Promise<ApiResponse>} The parsed API response.
+     * @throws {InvalidArgumentException} If `templateId` is empty.
      */
     async generate(templateId = '', _format = 'PDF', transactionId = '', fillData=null) {
         if(!fillData)
@@ -451,11 +536,12 @@ class Contract extends _ApiParent {
     /**
      * Retrieve a list of contract templates
      *
-     * @param order Sort results by newest(-1) or oldest(1)
-     * @param limit Number of items to be returned per call
-     * @param offset Start the list from a particular entry index
-     * @param filterTemplateId Filter result by template ID
-     * @returns {Promise<*>}
+     * @param {number} [order=-1] Sort results by newest(-1) or oldest(1).
+     * @param {number} [limit=10] Number of items to be returned per call.
+     * @param {number} [offset=0] Start the list from a particular entry index.
+     * @param {string} [filterTemplateId=""] Filter result by template ID.
+     * @returns {Promise<ApiResponse>} The parsed API response.
+     * @throws {InvalidArgumentException} If `order` is not 1 or -1, or `limit` is out of range.
      */
     async listTemplate(order = -1, limit = 10, offset = 0, filterTemplateId = "") {
         if(order !== -1 && order !== 1) {
@@ -483,8 +569,9 @@ class Contract extends _ApiParent {
     /**
      * Get contract template
      *
-     * @param templateId Template ID
-     * @returns {Promise<*>}
+     * @param {string} [templateId=""] Template ID.
+     * @returns {Promise<ApiResponse>} The parsed API response.
+     * @throws {InvalidArgumentException} If `templateId` is empty.
      */
     async getTemplate(templateId = "") {
         if(templateId === '') {
@@ -500,8 +587,9 @@ class Contract extends _ApiParent {
     /**
      * Delete contract template
      *
-     * @param templateId Template ID
-     * @returns {Promise<*>}
+     * @param {string} [templateId=""] Template ID.
+     * @returns {Promise<ApiResponse>} The parsed API response.
+     * @throws {InvalidArgumentException} If `templateId` is empty.
      */
     async deleteTemplate(templateId = "") {
         if(templateId === '') {
@@ -516,12 +604,13 @@ class Contract extends _ApiParent {
     /**
      * Create new contract template
      *
-     * @param name Template name
-     * @param content Template HTML content
-     * @param orientation 0=Portrait(Default) 1=Landscape
-     * @param timezone Template timezone
-     * @param font Template font
-     * @returns {Promise<*>}
+     * @param {string} [name=""] Template name.
+     * @param {string} [content=""] Template HTML content.
+     * @param {string} [orientation="0"] Page orientation: 0=Portrait(Default), 1=Landscape.
+     * @param {string} [timezone="UTC"] Template timezone.
+     * @param {string} [font="Open Sans"] Template font.
+     * @returns {Promise<ApiResponse>} The parsed API response.
+     * @throws {InvalidArgumentException} If `name` or `content` is empty.
      */
     async createTemplate(name = "", content = "", orientation = "0", timezone = "UTC", font = "Open Sans") {
         if(name === '') {
@@ -547,13 +636,14 @@ class Contract extends _ApiParent {
     /**
      * Update contract template
      *
-     * @param templateId Template ID
-     * @param name Template name
-     * @param content Template HTML content
-     * @param orientation 0=Portrait(Default) 1=Landscape
-     * @param timezone Template timezone
-     * @param font Template font
-     * @returns {Promise<*>}
+     * @param {string} [templateId=""] Template ID.
+     * @param {string} [name=""] Template name.
+     * @param {string} [content=""] Template HTML content.
+     * @param {string} [orientation="0"] Page orientation: 0=Portrait(Default), 1=Landscape.
+     * @param {string} [timezone="UTC"] Template timezone.
+     * @param {string} [font="Open Sans"] Template font.
+     * @returns {Promise<ApiResponse>} The parsed API response.
+     * @throws {InvalidArgumentException} If `templateId`, `name`, or `content` is empty.
      */
     async updateTemplate(templateId = "", name = "", content = "", orientation = "0", timezone = "UTC", font = "Open Sans") {
         if(templateId === "") {
@@ -579,10 +669,19 @@ class Contract extends _ApiParent {
     }
 }
 
+/**
+ * Scanner API client. Initiates identity document scans (full KYC scan, plus
+ * quick/very-quick OCR-only variants), and configures verification, document
+ * restrictions and contract generation for the scan.
+ *
+ * @augments _ApiParent
+ */
 class Scanner extends _ApiParent {
     /**
+     * Create a new Scanner API client.
      *
-     * @param apiKey You API key
+     * @param {string|null} [apiKey=null] Your API key. If omitted, the
+     *   `IDANALYZER_KEY` environment variable is used.
      */
     constructor(apiKey = null) {
         super(apiKey);
@@ -610,7 +709,8 @@ class Scanner extends _ApiParent {
     /**
      * Pass in user IP address to check if ID is issued from the same country as the IP address, if no value is provided http connection IP will be used.
      *
-     * @param ip
+     * @param {string} ip User IP address. If empty, the HTTP connection IP is used.
+     * @returns {void}
      */
     setUserIp(ip) {
         this.config['ip'] = ip
@@ -619,7 +719,8 @@ class Scanner extends _ApiParent {
     /**
      * Set an arbitrary string you wish to save with the transaction. e.g Internal customer reference number
      *
-     * @param customData
+     * @param {string} customData Arbitrary string to store alongside the transaction.
+     * @returns {void}
      */
     setCustomData(customData) {
         this.config['customData'] = customData
@@ -628,9 +729,10 @@ class Scanner extends _ApiParent {
     /**
      * Automatically generate contract document using value parsed from uploaded ID
      *
-     * @param templateId Enter up to 5 contract template ID (seperated by comma)
-     * @param _format PDF, DOCX or HTML
-     * @param {*} extraFillData - Array data in key-value pairs to autofill dynamic fields, data from user ID will be used first in case of a conflict. For example, passing {"myparameter":"abc"} would fill %{myparameter} in contract template with "abc".
+     * @param {string} [templateId=""] Up to 5 contract template IDs (separated by comma). Pass an empty string to disable contract generation.
+     * @param {string} [_format="PDF"] Output format: PDF, DOCX or HTML.
+     * @param {Object<string, *>|null} [extraFillData=null] Key-value pairs to autofill dynamic fields. Data from the user ID is used first in case of a conflict. For example, passing `{"myparameter":"abc"}` would fill `%{myparameter}` in the contract template with "abc".
+     * @returns {void}
      */
     setContractOptions(templateId = "", _format = "PDF", extraFillData = null) {
         if(!extraFillData) {
@@ -654,7 +756,9 @@ class Scanner extends _ApiParent {
     /**
      * Set KYC Profile
      *
-     * @param profile KYCProfile object
+     * @param {Profile} profile KYC {@link Profile} object.
+     * @returns {void}
+     * @throws {InvalidArgumentException} If `profile` is not a {@link Profile} instance.
      */
     setProfile(profile) {
         if(profile instanceof Profile) {
@@ -672,12 +776,14 @@ class Scanner extends _ApiParent {
     /**
      * Check if customer information matches with uploaded document
      *
-     * @param documentNumber Document or ID number
-     * @param fullName Full name
-     * @param dob Date of birth in YYYY/MM/DD
-     * @param ageRange Age range, example: 18-40
-     * @param address Address
-     * @param postcode Postcode
+     * @param {string} [documentNumber=""] Document or ID number.
+     * @param {string} [fullName=""] Full name.
+     * @param {string} [dob=""] Date of birth in YYYY/MM/DD.
+     * @param {string} [ageRange=""] Age range, example: 18-40.
+     * @param {string} [address=""] Address.
+     * @param {string} [postcode=""] Postcode.
+     * @returns {void}
+     * @throws {InvalidArgumentException} If `dob` is not in YYYY/MM/DD format or `ageRange` is not in minAge-maxAge format.
      */
     verifyUserInformation(documentNumber = "", fullName = "", dob = "", ageRange = "",
                           address = "", postcode = "") {
@@ -710,7 +816,8 @@ class Scanner extends _ApiParent {
     /**
      * Check if the document was issued by specified countries. Separate multiple values with comma. For example "US,CA" would accept documents from the United States and Canada.
      *
-     * @param countryCodes ISO ALPHA-2 Country Code separated by comma
+     * @param {string} [countryCodes="US,CA,UK"] ISO ALPHA-2 Country Code separated by comma.
+     * @returns {void}
      */
     restrictCountry(countryCodes="US,CA,UK") {
         this.config['restrictCountry'] = countryCodes
@@ -719,7 +826,8 @@ class Scanner extends _ApiParent {
     /**
      * Check if the document was issued by specified state. Separate multiple values with comma. For example "CA,TX" would accept documents from California and Texas.
      *
-     * @param states State full name or abbreviation separated by comma
+     * @param {string} [states='CA,TX'] State full name or abbreviation separated by comma.
+     * @returns {void}
      */
     restrictState(states = 'CA,TX') {
         this.config['restrictState'] = states
@@ -728,7 +836,8 @@ class Scanner extends _ApiParent {
     /**
      * Check if the document was one of the specified types. For example, "PD" would accept both passport and driver license.
      *
-     * @param documentType P: Passport, D: Driver's License, I: Identity Card
+     * @param {string} [documentType='DIP'] P: Passport, D: Driver's License, I: Identity Card.
+     * @returns {void}
      */
     restrictType(documentType = 'DIP') {
         this.config['restrictType'] = documentType
@@ -737,11 +846,12 @@ class Scanner extends _ApiParent {
     /**
      * Initiate a new identity document scan & ID face verification transaction by providing input images.
      *
-     * @param documentFront Front of Document (file path, base64 content, url, or cache reference)
-     * @param documentBack Back of Document (file path, base64 content or URL, or cache reference)
-     * @param facePhoto Face Photo (file path, base64 content or URL, or cache reference)
-     * @param faceVideo Face Video (file path, base64 content or URL)
-     * @returns {Promise<*>}
+     * @param {string} [documentFront=""] Front of Document (file path, base64 content, URL, or cache reference).
+     * @param {string} [documentBack=""] Back of Document (file path, base64 content or URL, or cache reference).
+     * @param {string} [facePhoto=""] Face Photo (file path, base64 content or URL, or cache reference). Provide either this or `faceVideo`.
+     * @param {string} [faceVideo=""] Face Video (file path, base64 content or URL). Used if `facePhoto` is empty.
+     * @returns {Promise<ApiResponse>} The parsed API response.
+     * @throws {InvalidArgumentException} If no profile is configured or `documentFront` is empty.
      */
     async scan(documentFront = "", documentBack = "", facePhoto = "", faceVideo = "") {
         if(this.config['profile'] === '') {
@@ -772,10 +882,11 @@ class Scanner extends _ApiParent {
     /**
      * Initiate a quick identity document OCR scan by providing input images.
      *
-     * @param documentFront Front of Document (file path, base64 content or URL)
-     * @param documentBack Back of Document (file path, base64 content or URL)
-     * @param cacheImage Cache uploaded image(s) for 24 hours and obtain a cache reference for each image, the reference hash can be used to start standard scan transaction without re-uploading the file.
-     * @returns {Promise<*>}
+     * @param {string} [documentFront=""] Front of Document (file path, base64 content or URL).
+     * @param {string} [documentBack=""] Back of Document (file path, base64 content or URL).
+     * @param {boolean} [cacheImage=false] Cache uploaded image(s) for 24 hours and obtain a cache reference for each image; the reference hash can be used to start a standard scan transaction without re-uploading the file.
+     * @returns {Promise<ApiResponse>} The parsed API response.
+     * @throws {InvalidArgumentException} If `documentFront` is empty.
      */
     async quickScan(documentFront = "", documentBack = "", cacheImage = false) {
         let payload = {
@@ -799,10 +910,11 @@ class Scanner extends _ApiParent {
      * Initiate a very quick (fast) identity document OCR scan by providing input images. Faster but less
      * thorough than quickScan, useful for high-throughput OCR-only use cases.
      *
-     * @param documentFront Front of Document (file path, base64 content or URL)
-     * @param documentBack Back of Document (file path, base64 content or URL)
-     * @param cacheImage Cache uploaded image(s) for 24 hours and obtain a cache reference for each image, the reference hash can be used to start standard scan transaction without re-uploading the file.
-     * @returns {Promise<*>}
+     * @param {string} [documentFront=""] Front of Document (file path, base64 content or URL).
+     * @param {string} [documentBack=""] Back of Document (file path, base64 content or URL).
+     * @param {boolean} [cacheImage=false] Cache uploaded image(s) for 24 hours and obtain a cache reference for each image; the reference hash can be used to start a standard scan transaction without re-uploading the file.
+     * @returns {Promise<ApiResponse>} The parsed API response.
+     * @throws {InvalidArgumentException} If `documentFront` is empty.
      */
     async veryQuickScan(documentFront = "", documentBack = "", cacheImage = false) {
         let payload = {
@@ -823,10 +935,18 @@ class Scanner extends _ApiParent {
     }
 }
 
+/**
+ * Transaction API client. Retrieves, lists, updates and deletes transaction
+ * records, and downloads transaction images, files and archive exports.
+ *
+ * @augments _ApiParent
+ */
 class Transaction extends _ApiParent {
     /**
+     * Create a new Transaction API client.
      *
-     * @param apiKey You API key
+     * @param {string|null} [apiKey=null] Your API key. If omitted, the
+     *   `IDANALYZER_KEY` environment variable is used.
      */
     constructor(apiKey=null) {
         super(apiKey);
@@ -835,8 +955,9 @@ class Transaction extends _ApiParent {
     /**
      * Retrieve a single transaction record
      *
-     * @param transactionId Transaction ID
-     * @returns {Promise<*>}
+     * @param {string} [transactionId=""] Transaction ID.
+     * @returns {Promise<ApiResponse>} The parsed API response.
+     * @throws {InvalidArgumentException} If `transactionId` is empty.
      */
     async getTransaction(transactionId = "") {
         if(transactionId === "") {
@@ -851,16 +972,17 @@ class Transaction extends _ApiParent {
     /**
      * Retrieve a list of transaction history
      *
-     * @param order Sort results by newest(-1) or oldest(1)
-     * @param limit Number of items to be returned per call
-     * @param offset Start the list from a particular entry index
-     * @param createdAtMin List transactions that were created after this timestamp
-     * @param createdAtMax List transactions that were created before this timestamp
-     * @param filterCustomData Filter result by customData field
-     * @param filterDecision Filter result by decision (accept, review, reject)
-     * @param filterDocupass Filter result by Docupass reference
-     * @param filterProfileId Filter result by KYC Profile ID
-     * @returns {Promise<*>}
+     * @param {number} [order=-1] Sort results by newest(-1) or oldest(1).
+     * @param {number} [limit=10] Number of items to be returned per call.
+     * @param {number} [offset=0] Start the list from a particular entry index.
+     * @param {number} [createdAtMin=0] List transactions that were created after this UNIX timestamp.
+     * @param {number} [createdAtMax=0] List transactions that were created before this UNIX timestamp.
+     * @param {string} [filterCustomData=""] Filter result by customData field.
+     * @param {string} [filterDecision=""] Filter result by decision (accept, review, reject).
+     * @param {string} [filterDocupass=""] Filter result by Docupass reference.
+     * @param {string} [filterProfileId=""] Filter result by KYC Profile ID.
+     * @returns {Promise<ApiResponse>} The parsed API response.
+     * @throws {InvalidArgumentException} If `order` is not 1 or -1, or `limit` is out of range.
      */
     async listTransaction(order = -1, limit = 10, offset = 0, createdAtMin = 0,
                           createdAtMax = 0, filterCustomData = "", filterDecision = "",
@@ -906,9 +1028,10 @@ class Transaction extends _ApiParent {
     /**
      * Update transaction decision, updated decision will be relayed to webhook if set.
      *
-     * @param transactionId Transaction ID
-     * @param decision New decision (accept, review or reject)
-     * @returns {Promise<*>}
+     * @param {string} [transactionId=""] Transaction ID.
+     * @param {string} [decision=""] New decision (accept, review or reject).
+     * @returns {Promise<ApiResponse>} The parsed API response.
+     * @throws {InvalidArgumentException} If `transactionId` is empty or `decision` is not one of accept/review/reject.
      */
     async updateTransaction(transactionId = "", decision = "") {
         if(transactionId === "") {
@@ -927,8 +1050,9 @@ class Transaction extends _ApiParent {
     /**
      * Delete a transaction
      *
-     * @param transactionId Transaction ID
-     * @returns {Promise<*>}
+     * @param {string} [transactionId=""] Transaction ID.
+     * @returns {Promise<ApiResponse>} The parsed API response.
+     * @throws {InvalidArgumentException} If `transactionId` is empty.
      */
     async deleteTransaction(transactionId = "") {
         if(transactionId === "") {
@@ -943,9 +1067,10 @@ class Transaction extends _ApiParent {
     /**
      * Download transaction image onto local file system
      *
-     * @param imageToken Image token from transaction API response
-     * @param destination Full destination path including file name, file extension should be jpg, for example: '\home\idcard.jpg'
-     * @returns {Promise<void>}
+     * @param {string} [imageToken=""] Image token from the transaction API response.
+     * @param {string} [destination=""] Full destination path including file name; the file extension should be jpg, for example: '\home\idcard.jpg'.
+     * @returns {Promise<void>} Resolves once the download stream has been piped to disk.
+     * @throws {InvalidArgumentException} If `imageToken` or `destination` is empty.
      */
     async saveImage(imageToken = "", destination = "") {
         if(imageToken === "") {
@@ -964,9 +1089,10 @@ class Transaction extends _ApiParent {
     /**
      * Download transaction file onto local file system using secured file name obtained from transaction
      *
-     * @param fileName Secured file name
-     * @param destination Full destination path including file name, for example: '\home\auditreport.pdf'
-     * @returns {Promise<void>}
+     * @param {string} [fileName=""] Secured file name obtained from the transaction.
+     * @param {string} [destination=""] Full destination path including file name, for example: '\home\auditreport.pdf'.
+     * @returns {Promise<void>} Resolves once the download stream has been piped to disk.
+     * @throws {InvalidArgumentException} If `fileName` or `destination` is empty.
      */
     async saveFile(fileName = "", destination = "") {
         if (fileName === "")
@@ -984,18 +1110,19 @@ class Transaction extends _ApiParent {
     /**
      * Download transaction archive onto local file system
      *
-     * @param destination Full destination path including file name, file extension should be zip, for example: '\home\archive.zip'
-     * @param exportType 'csv' or 'json'
-     * @param ignoreUnrecognized Ignore unrecognized documents
-     * @param ignoreDuplicate Ignore duplicated entries
-     * @param transactionId Export only the specified transaction IDs
-     * @param createdAtMin Export only transactions that were created after this timestamp
-     * @param createdAtMax Export only transactions that were created before this timestamp
-     * @param filterCustomData Filter export by customData field
-     * @param filterDecision Filter export by decision (accept, review, reject)
-     * @param filterDocupass Filter export by Docupass reference
-     * @param filterProfileId Filter export by KYC Profile ID
-     * @returns {Promise<void>}
+     * @param {string} [destination=""] Full destination path including file name; the file extension should be zip, for example: '\home\archive.zip'.
+     * @param {string[]|null} [transactionId=null] Export only the specified transaction IDs. Pass `null` to export all matching transactions.
+     * @param {string} [exportType="csv"] Export format, either 'csv' or 'json'.
+     * @param {boolean} [ignoreUnrecognized=false] Ignore unrecognized documents.
+     * @param {boolean} [ignoreDuplicate=false] Ignore duplicated entries.
+     * @param {number} [createdAtMin=0] Export only transactions that were created after this UNIX timestamp.
+     * @param {number} [createdAtMax=0] Export only transactions that were created before this UNIX timestamp.
+     * @param {string} [filterCustomData=""] Filter export by customData field.
+     * @param {string} [filterDecision=""] Filter export by decision (accept, review, reject).
+     * @param {string} [filterDocupass=""] Filter export by Docupass reference.
+     * @param {string} [filterProfileId=""] Filter export by KYC Profile ID.
+     * @returns {Promise<void>} Resolves once the export archive has been downloaded and piped to disk (if the API returned a download URL).
+     * @throws {InvalidArgumentException} If `destination` is empty or `exportType` is not 'csv' or 'json'.
      */
     async exportTransaction(destination = "", transactionId = null, exportType = "csv", ignoreUnrecognized = false,
                             ignoreDuplicate = false, createdAtMin = 0,
@@ -1050,20 +1177,31 @@ class Transaction extends _ApiParent {
     }
 }
 
+/**
+ * Docupass API client. Creates, lists, retrieves and deletes Docupass
+ * verification sessions (hosted ID verification links/forms).
+ *
+ * @augments _ApiParent
+ */
 class Docupass extends _ApiParent {
     /**
+     * Create a new Docupass API client.
      *
-     * @param apiKey You API key
+     * @param {string|null} [apiKey=null] Your API key. If omitted, the
+     *   `IDANALYZER_KEY` environment variable is used.
      */
     constructor(apiKey = null) {
         super(apiKey);
     }
 
     /**
-     * @param order
-     * @param limit
-     * @param offset
-     * @returns {Promise<*>}
+     * Retrieve a list of Docupass sessions.
+     *
+     * @param {number} [order=-1] Sort results by newest(-1) or oldest(1).
+     * @param {number} [limit=10] Number of items to be returned per call.
+     * @param {number} [offset=0] Start the list from a particular entry index.
+     * @returns {Promise<ApiResponse>} The parsed API response.
+     * @throws {InvalidArgumentException} If `order` is not 1 or -1, or `limit` is out of range.
      */
     async listDocupass(order = -1, limit = 10, offset = 0) {
         if(order !== 1 && order !== -1) {
@@ -1089,8 +1227,9 @@ class Docupass extends _ApiParent {
     /**
      * Retrieve a single Docupass record by reference.
      *
-     * @param reference Docupass reference ID
-     * @returns {Promise<*>}
+     * @param {string} [reference=''] Docupass reference ID.
+     * @returns {Promise<ApiResponse>} The parsed API response.
+     * @throws {InvalidArgumentException} If `reference` is empty.
      */
     async getDocupass(reference = '') {
         if(reference === '') {
@@ -1103,27 +1242,29 @@ class Docupass extends _ApiParent {
     }
 
     /**
+     * Create a new Docupass verification session.
      *
-     * @param mode
-     * @param profile
-     * @param contractFormat
-     * @param contractGenerate
-     * @param reusable
-     * @param contractPrefill
-     * @param contractSign
-     * @param customData
-     * @param language
-     * @param referenceDocument
-     * @param referenceDocumentBack
-     * @param referenceFace
-     * @param userPhone
-     * @param verifyAddress
-     * @param verifyAge
-     * @param verifyDOB
-     * @param verifyDocumentNumber
-     * @param verifyName
-     * @param verifyPostcode
-     * @returns {Promise<*>}
+     * @param {string|null} [profile=null] KYC Profile ID to apply to the verification. Required.
+     * @param {number} [mode=0] Docupass verification mode (e.g. 0=document + face, see API docs for available modes).
+     * @param {string} [contractFormat='pdf'] Generated contract format: 'pdf', 'docx' or 'html'.
+     * @param {string} [contractGenerate=''] Contract template ID(s) to auto-generate on completion.
+     * @param {boolean} [reusable=false] Whether the Docupass link can be reused by multiple users.
+     * @param {string} [contractPrefill=''] Key-value data used to prefill the generated contract.
+     * @param {string} [contractSign=''] Contract signing configuration.
+     * @param {string} [customData=''] Arbitrary string to store alongside the resulting transaction.
+     * @param {string} [language=''] Display language for the Docupass page (e.g. 'en').
+     * @param {string|null} [referenceDocument=null] Reference document front image to verify against.
+     * @param {string|null} [referenceDocumentBack=null] Reference document back image to verify against.
+     * @param {string|null} [referenceFace=null] Reference face image to verify against.
+     * @param {string} [userPhone=''] User phone number.
+     * @param {string} [verifyAddress=''] Address to verify against the submitted document.
+     * @param {string} [verifyAge=''] Age range (e.g. "18-99") to verify against the submitted document.
+     * @param {string} [verifyDOB=''] Date of birth (YYYY/MM/DD) to verify against the submitted document.
+     * @param {string} [verifyDocumentNumber=''] Document/ID number to verify against the submitted document.
+     * @param {string} [verifyName=''] Full name to verify against the submitted document.
+     * @param {string} [verifyPostcode=''] Postcode to verify against the submitted document.
+     * @returns {Promise<ApiResponse>} The parsed API response.
+     * @throws {InvalidArgumentException} If `profile` is `null`.
      */
     async createDocupass(profile=null, mode=0, contractFormat='pdf', contractGenerate='', reusable=false,
                          contractPrefill='',
@@ -1177,9 +1318,11 @@ class Docupass extends _ApiParent {
     }
 
     /**
+     * Delete a Docupass session by reference.
      *
-     * @param reference
-     * @returns {Promise<*>}
+     * @param {string} [reference=''] Docupass reference ID.
+     * @returns {Promise<ApiResponse>} The parsed API response.
+     * @throws {InvalidArgumentException} If `reference` is empty.
      */
     async deleteDocupass(reference='') {
         if(reference === '') {
@@ -1193,9 +1336,18 @@ class Docupass extends _ApiParent {
 }
 
 
+/**
+ * AML (Anti-Money-Laundering) API client. Searches sanction, PEP and watchlist
+ * databases via the v1 and v3 search endpoints.
+ *
+ * @augments _ApiParent
+ */
 class AML extends _ApiParent {
     /**
-     * @param apiKey Your API key
+     * Create a new AML API client.
+     *
+     * @param {string|null} [apiKey=null] Your API key. If omitted, the
+     *   `IDANALYZER_KEY` environment variable is used.
      */
     constructor(apiKey = null) {
         super(apiKey);
@@ -1204,13 +1356,14 @@ class AML extends _ApiParent {
     /**
      * Search the AML database (v1 endpoint).
      *
-     * @param name Search AML database with person's name or business name
-     * @param idNumber Search AML database with document number
-     * @param entity 0=Person, 1=Corporation/Legal Entity
-     * @param country Two digit ISO country code to filter by country/nationality
-     * @param database Optional array of databases to search, e.g. ["us_ofac","eu_fsf"]. If omitted all databases are searched.
-     * @param birthYear Filter by year of birth
-     * @returns {Promise<*>}
+     * @param {string} [name=""] Search AML database with a person's name or business name.
+     * @param {string} [idNumber=""] Search AML database with a document number.
+     * @param {number} [entity=0] Entity type: 0=Person, 1=Corporation/Legal Entity.
+     * @param {string} [country=""] Two-digit ISO country code to filter by country/nationality.
+     * @param {string[]|null} [database=null] Optional array of databases to search, e.g. ["us_ofac","eu_fsf"]. If omitted, all databases are searched.
+     * @param {string} [birthYear=""] Filter by year of birth.
+     * @returns {Promise<ApiResponse>} The parsed API response.
+     * @throws {InvalidArgumentException} If both `name` and `idNumber` are empty.
      */
     async search(name = "", idNumber = "", entity = 0, country = "", database = null, birthYear = "") {
         if(name === "" && idNumber === "") {
@@ -1230,11 +1383,12 @@ class AML extends _ApiParent {
     /**
      * Search the AML database (v3 endpoint). Provide either a free-text query or one or more entity IDs.
      *
-     * @param text Full-text query (name, alias, document/passport/tax/registration number, etc.)
-     * @param id One or more AML entity IDs separated by comma or newline (max 50)
-     * @param limit Number of results to return per page
-     * @param page Result page number
-     * @returns {Promise<*>}
+     * @param {string} [text=""] Full-text query (name, alias, document/passport/tax/registration number, etc.).
+     * @param {string} [id=""] One or more AML entity IDs separated by comma or newline (max 50).
+     * @param {number} [limit=0] Number of results to return per page. 0 uses the API default.
+     * @param {number} [page=0] Result page number. 0 uses the API default.
+     * @returns {Promise<ApiResponse>} The parsed API response.
+     * @throws {InvalidArgumentException} If both `text` and `id` are empty.
      */
     async searchV3(text = "", id = "", limit = 0, page = 0) {
         if(text === "" && id === "") {
@@ -1251,14 +1405,33 @@ class AML extends _ApiParent {
     }
 }
 
+/**
+ * Profile API client. Manages stored KYC profiles on your account
+ * (list, retrieve, create, update, delete and export).
+ *
+ * @augments _ApiParent
+ */
 class ProfileAPI extends _ApiParent {
     /**
-     * @param apiKey Your API key
+     * Create a new Profile API client.
+     *
+     * @param {string|null} [apiKey=null] Your API key. If omitted, the
+     *   `IDANALYZER_KEY` environment variable is used.
      */
     constructor(apiKey = null) {
         super(apiKey);
     }
 
+    /**
+     * Build the request body for create/update profile calls from a name and a
+     * {@link Profile} object or plain config object.
+     *
+     * @private
+     * @param {string} name Profile name (omitted from the body if empty).
+     * @param {Profile|Object<string, *>|null} profile A {@link Profile} instance (its overrides are used) or a plain config object.
+     * @returns {Object<string, *>} The assembled request body.
+     * @throws {InvalidArgumentException} If `profile` is provided but is neither a {@link Profile} nor a plain object.
+     */
     static _profileBody(name, profile) {
         let body = {}
         if(name !== "") body['name'] = name
@@ -1276,7 +1449,12 @@ class ProfileAPI extends _ApiParent {
 
     /**
      * List KYC profiles.
-     * @returns {Promise<*>}
+     *
+     * @param {number} [order=-1] Sort results by newest(-1) or oldest(1).
+     * @param {number} [limit=10] Number of items to be returned per call.
+     * @param {number} [offset=0] Start the list from a particular entry index.
+     * @returns {Promise<ApiResponse>} The parsed API response.
+     * @throws {InvalidArgumentException} If `order` is not 1 or -1.
      */
     async listProfile(order = -1, limit = 10, offset = 0) {
         if(order !== -1 && order !== 1) {
@@ -1291,7 +1469,10 @@ class ProfileAPI extends _ApiParent {
 
     /**
      * Retrieve a single KYC profile.
-     * @returns {Promise<*>}
+     *
+     * @param {string} [profileId=""] KYC profile ID.
+     * @returns {Promise<ApiResponse>} The parsed API response.
+     * @throws {InvalidArgumentException} If `profileId` is empty.
      */
     async getProfile(profileId = "") {
         if(profileId === "") throw new InvalidArgumentException("'profileId' required.")
@@ -1301,9 +1482,11 @@ class ProfileAPI extends _ApiParent {
 
     /**
      * Create a new KYC profile.
-     * @param name Profile name
-     * @param profile A Profile object (its overrides become the profile config) or a plain object
-     * @returns {Promise<*>}
+     *
+     * @param {string} [name=""] Profile name.
+     * @param {Profile|Object<string, *>|null} [profile=null] A {@link Profile} object (its overrides become the profile config) or a plain object.
+     * @returns {Promise<ApiResponse>} The parsed API response.
+     * @throws {InvalidArgumentException} If `name` is empty, or `profile` is an unsupported type.
      */
     async createProfile(name = "", profile = null) {
         if(name === "") throw new InvalidArgumentException("Profile name required.")
@@ -1313,7 +1496,12 @@ class ProfileAPI extends _ApiParent {
 
     /**
      * Update an existing KYC profile.
-     * @returns {Promise<*>}
+     *
+     * @param {string} [profileId=""] KYC profile ID.
+     * @param {string} [name=""] New profile name.
+     * @param {Profile|Object<string, *>|null} [profile=null] A {@link Profile} object (its overrides become the profile config) or a plain object.
+     * @returns {Promise<ApiResponse>} The parsed API response.
+     * @throws {InvalidArgumentException} If `profileId` is empty, or `profile` is an unsupported type.
      */
     async updateProfile(profileId = "", name = "", profile = null) {
         if(profileId === "") throw new InvalidArgumentException("'profileId' required.")
@@ -1323,7 +1511,10 @@ class ProfileAPI extends _ApiParent {
 
     /**
      * Delete a KYC profile.
-     * @returns {Promise<*>}
+     *
+     * @param {string} [profileId=""] KYC profile ID.
+     * @returns {Promise<ApiResponse>} The parsed API response.
+     * @throws {InvalidArgumentException} If `profileId` is empty.
      */
     async deleteProfile(profileId = "") {
         if(profileId === "") throw new InvalidArgumentException("'profileId' required.")
@@ -1333,7 +1524,10 @@ class ProfileAPI extends _ApiParent {
 
     /**
      * Export a KYC profile (GET /export/profile/{id}).
-     * @returns {Promise<*>}
+     *
+     * @param {string} [profileId=""] KYC profile ID.
+     * @returns {Promise<ApiResponse>} The parsed API response.
+     * @throws {InvalidArgumentException} If `profileId` is empty.
      */
     async exportProfile(profileId = "") {
         if(profileId === "") throw new InvalidArgumentException("'profileId' required.")
@@ -1342,9 +1536,18 @@ class ProfileAPI extends _ApiParent {
     }
 }
 
+/**
+ * Webhook API client. Lists webhook delivery logs and allows resending or
+ * deleting individual delivery records.
+ *
+ * @augments _ApiParent
+ */
 class Webhook extends _ApiParent {
     /**
-     * @param apiKey Your API key
+     * Create a new Webhook API client.
+     *
+     * @param {string|null} [apiKey=null] Your API key. If omitted, the
+     *   `IDANALYZER_KEY` environment variable is used.
      */
     constructor(apiKey = null) {
         super(apiKey);
@@ -1352,7 +1555,15 @@ class Webhook extends _ApiParent {
 
     /**
      * List webhook delivery logs.
-     * @returns {Promise<*>}
+     *
+     * @param {number} [order=-1] Sort results by newest(-1) or oldest(1).
+     * @param {number} [limit=10] Number of items to be returned per call.
+     * @param {number} [offset=0] Start the list from a particular entry index.
+     * @param {string} [event=""] Filter by event type.
+     * @param {number} [success=-1] Filter by delivery success: 1=success, 0=failure, -1=no filter.
+     * @param {string} [createdAtMin=""] List deliveries created after this timestamp.
+     * @param {string} [createdAtMax=""] List deliveries created before this timestamp.
+     * @returns {Promise<ApiResponse>} The parsed API response.
      */
     async listWebhook(order = -1, limit = 10, offset = 0, event = "", success = -1, createdAtMin = "", createdAtMax = "") {
         let payload = {order, limit, offset}
@@ -1366,7 +1577,10 @@ class Webhook extends _ApiParent {
 
     /**
      * Resend a webhook delivery.
-     * @returns {Promise<*>}
+     *
+     * @param {string} [webhookId=""] Webhook delivery ID.
+     * @returns {Promise<ApiResponse>} The parsed API response.
+     * @throws {InvalidArgumentException} If `webhookId` is empty.
      */
     async resendWebhook(webhookId = "") {
         if(webhookId === "") throw new InvalidArgumentException("'webhookId' required.")
@@ -1376,7 +1590,10 @@ class Webhook extends _ApiParent {
 
     /**
      * Delete a webhook delivery log.
-     * @returns {Promise<*>}
+     *
+     * @param {string} [webhookId=""] Webhook delivery ID.
+     * @returns {Promise<ApiResponse>} The parsed API response.
+     * @throws {InvalidArgumentException} If `webhookId` is empty.
      */
     async deleteWebhook(webhookId = "") {
         if(webhookId === "") throw new InvalidArgumentException("'webhookId' required.")
@@ -1385,9 +1602,17 @@ class Webhook extends _ApiParent {
     }
 }
 
+/**
+ * Account API client. Retrieves the current account's profile, quota and usage.
+ *
+ * @augments _ApiParent
+ */
 class Account extends _ApiParent {
     /**
-     * @param apiKey Your API key
+     * Create a new Account API client.
+     *
+     * @param {string|null} [apiKey=null] Your API key. If omitted, the
+     *   `IDANALYZER_KEY` environment variable is used.
      */
     constructor(apiKey = null) {
         super(apiKey);
@@ -1395,7 +1620,8 @@ class Account extends _ApiParent {
 
     /**
      * Retrieve current account profile, quota and usage.
-     * @returns {Promise<*>}
+     *
+     * @returns {Promise<ApiResponse>} The parsed API response containing account profile, quota and usage.
      */
     async getAccount() {
         let resp = await this.http.get(GetEndpoint('myaccount'), {timeout: 30000})
@@ -1403,4 +1629,8 @@ class Account extends _ApiParent {
     }
 }
 
+/**
+ * Public SDK surface: every API client class plus the {@link SetEndpoint}
+ * helper and the {@link APIError} / {@link InvalidArgumentException} error types.
+ */
 export {Profile, Biometric, Contract, Scanner, Transaction, Docupass, AML, ProfileAPI, Webhook, Account, SetEndpoint, APIError, InvalidArgumentException};


### PR DESCRIPTION
Completes the inline JSDoc/TSDoc API documentation across the SDK. Documentation/comments only — no runtime logic, signatures, or behavior changed; no version bump.

## What changed
- **lib/idanalyzer.js**: class-level descriptions for every exported class (`Profile`, `Biometric`, `Contract`, `Scanner`, `Transaction`, `Docupass`, `AML`, `ProfileAPI`, `Webhook`, `Account`) and the internal `_ApiParent`; documented every constructor, public method, static `SECURITY_*` constant, and the `ProfileAPI._profileBody` helper. Added `{type}` annotations, default-value notation, `@returns`, and `@throws` to every parameter/return. Filled in the previously-bare `Docupass` (`listDocupass`/`createDocupass`/`deleteDocupass`) docs and reordered the `createDocupass`/`exportTransaction` param lists to match their signatures. Added an `ApiResponse` `@typedef`.
- **lib/common.js**: documented `ParseInput`, `GetEndpoint`, `SetEndpoint`, `ApiExceptionHandle`, and the module-private `_endpoint` / `REGION_ENDPOINTS`.
- **lib/exception.js**: documented `APIError` (incl. `msg`/`code` members and constructor) and `InvalidArgumentException`.
- **index.js**: module-level overview comment.
- **index.d.ts**: added TSDoc comments to every class, method, parameter, return, the `ApiResponse` type, `SetEndpoint`, and the default-exported namespace; types unchanged.

## Verification
- `npm install` + `node -e "require('./index.js')"` → loads OK.
- `tsc --noEmit --strict index.d.ts` → no errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)