### PR TITLE
chore: sync package-lock version (1.1.1)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "idanalyzer2",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "idanalyzer2",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.7.7"


### PR DESCRIPTION
Lockfile version field catching up to the already-published package.json 1.1.1. No dependency changes.