### PR TITLE
ci: API reference docs to GitHub Pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,35 @@
+name: API docs
+on:
+  push:
+    branches: [main]
+    tags: ['v*']
+  workflow_dispatch:
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+concurrency:
+  group: pages
+  cancel-in-progress: false
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+      - run: npm install --no-audit --no-fund
+      - run: npx -y jsdoc@4 lib -r -R README.md -d site
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
Adds a GitHub Actions workflow that auto-generates the API reference from JSDoc comments in `lib/` and publishes it to GitHub Pages.

- Runs on push to `main`, on `v*` tags, and via manual dispatch.
- Generates HTML with `jsdoc@4 lib -r -R README.md -d site`.
- Deploys the `site` artifact via `actions/deploy-pages`.
- Pages already configured with the Actions (workflow) build type.

Published URL: https://idanalyzer.github.io/id-analyzer-v2-nodejs/