### PR TITLE
ci(docs): drop tag trigger (fixes Pages deploy failures on tags)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,7 +2,6 @@ name: API docs
 on:
   push:
     branches: [main]
-    tags: ['v*']
   workflow_dispatch:
 permissions:
   contents: read


### PR DESCRIPTION
The github-pages environment only allows deploys from main, so tag-triggered docs runs fail at deploy ('Tag vX is not allowed to deploy'). Docs already rebuild on every push to main, so the tag trigger is redundant. publish.yml is untouched.